### PR TITLE
Change config path

### DIFF
--- a/electroncash/util.py
+++ b/electroncash/util.py
@@ -456,17 +456,18 @@ def bh2u(x):
 
 
 def user_dir(prefer_local=False):
+    # fixme: rename the user dir when branding is decided
     if 'ANDROID_DATA' in os.environ:
         return android_data_dir()
     elif os.name == 'posix' and "HOME" in os.environ:
-        return os.path.join(os.environ["HOME"], ".electron-cash" )
+        return os.path.join(os.environ["HOME"], ".electron-cash-abc")
     elif "APPDATA" in os.environ or "LOCALAPPDATA" in os.environ:
         app_dir = os.environ.get("APPDATA")
         localapp_dir = os.environ.get("LOCALAPPDATA")
         # Prefer APPDATA, but may get LOCALAPPDATA if present and req'd.
         if localapp_dir is not None and prefer_local or app_dir is None:
             app_dir = localapp_dir
-        return os.path.join(app_dir, "ElectronCash")
+        return os.path.join(app_dir, "ElectronCashABC")
     else:
         #raise Exception("No home directory found in environment variables.")
         return


### PR DESCRIPTION
Do not reuse the same path for configuration files as ElectronCash. This config contains wallet files and previously used servers.