### PR TITLE
Change program name

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,7 @@ include README.rst
 include electron-cash.conf.sample
 include electron-cash.desktop
 include *.py
-include electron-cash
+include electrum-bcha
 include contrib/requirements/requirements.txt
 include contrib/requirements/requirements-hw.txt
 recursive-include electroncash *.py

--- a/contrib/base.sh
+++ b/contrib/base.sh
@@ -201,7 +201,7 @@ if [ "$GIT_REPO" != "$DEFAULT_GIT_REPO" ]; then
     info "Picked up override from env: GIT_REPO=${GIT_REPO}"
 fi
 export GIT_DIR_NAME=`basename $GIT_REPO`
-export PACKAGE="Electron-Cash"  # Modify this if you like -- Windows, MacOS & Linux srcdist build scripts read this, while AppImage has it hard-coded
+export PACKAGE="Electrum-BCHA"  # Modify this if you like -- Windows, MacOS & Linux srcdist build scripts read this, while AppImage has it hard-coded
 export PYI_SKIP_TAG="${PYI_SKIP_TAG:-0}" # Set this to non-zero to make PyInstaller skip tagging the bootloader
 
 # Build a command line argument for docker, enabling interactive mode if stdin

--- a/contrib/base.sh
+++ b/contrib/base.sh
@@ -187,7 +187,7 @@ export SOURCE_DATE_EPOCH=1530212462
 # If the manifest changed, contrib/build-wine/manifest.xml needs to be updated.
 export PYTHON_VERSION=3.6.9  # Windows, OSX & Linux AppImage use this to determine what to download/build
 export PYTHON_SRC_TARBALL_HASH="5e2f5f554e3f8f7f0296f7e73d8600c4e9acbaee6b2555b83206edf5153870da"  # If you change PYTHON_VERSION above, update this by downloading the tarball manually and doing a sha256sum on it.
-export DEFAULT_GIT_REPO=https://github.com/PiRK/Electron-Cash
+export DEFAULT_GIT_REPO=https://github.com/PiRK/ElectrumBCHA
 if [ -z "$GIT_REPO" ] ; then
     # If no override from env is present, use default. Support for overrides
     # for the GIT_REPO has been added to allows contributors to test containers

--- a/contrib/build-wine/_build.sh
+++ b/contrib/build-wine/_build.sh
@@ -234,14 +234,14 @@ build_the_app() {
         find -exec touch -d '2000-11-11T11:11:11+00:00' {} +
         popd  # go back to $here
 
-        cp -r "$here"/../electrum-locale/locale $WINEPREFIX/drive_c/electroncash/electroncash/
+        cp -rv "$here"/../electrum-locale/locale $WINEPREFIX/drive_c/electrumbcha/electroncash/
 
         # Install frozen dependencies
         info "Installing frozen dependencies ..."
         $PYTHON -m pip install --no-warn-script-location -r "$here"/../deterministic-build/requirements.txt || fail "Failed to install requirements"
         $PYTHON -m pip install --no-warn-script-location -r "$here"/../deterministic-build/requirements-hw.txt || fail "Failed to install requirements-hw"
 
-        pushd $WINEPREFIX/drive_c/electroncash
+        pushd $WINEPREFIX/drive_c/electrumbcha
         $PYTHON setup.py install || fail "Failed setup.py install"
         popd
 

--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -14,7 +14,7 @@ else
 fi
 
 if [ ! -d 'contrib' ]; then
-    fail "Please run this script form the top-level Electron Cash git directory"
+    fail "Please run this script form the top-level Electrum BCHA git directory"
 fi
 
 pushd .
@@ -62,8 +62,8 @@ $SUDO docker build -t $IMGNAME \
     || fail "Failed to create docker image"
 
 # This is the place where we checkout and put the exact revision we want to work
-# on. Docker will run mapping this directory to /homedir/wine64/drive_c/electroncash
-# which inside wine will look like c:\electroncash.
+# on. Docker will run mapping this directory to /homedir/wine64/drive_c/electrumbcha
+# which inside wine will look like c:\electrumbcha.
 FRESH_CLONE=`pwd`/contrib/build-wine/fresh_clone
 FRESH_CLONE_DIR="$FRESH_CLONE/$GIT_DIR_NAME"
 
@@ -86,9 +86,9 @@ FRESH_CLONE_DIR="$FRESH_CLONE/$GIT_DIR_NAME"
     -e BUILD_DEBUG="$BUILD_DEBUG" \
     -e PYI_SKIP_TAG="$PYI_SKIP_TAG" \
     --name ec-wine-builder-cont \
-    -v "$FRESH_CLONE_DIR":/homedir/wine64/drive_c/electroncash:delegated \
+    -v "$FRESH_CLONE_DIR":/homedir/wine64/drive_c/electrumbcha:delegated \
     --rm \
-    --workdir /homedir/wine64/drive_c/electroncash/contrib/build-wine \
+    --workdir /homedir/wine64/drive_c/electrumbcha/contrib/build-wine \
     $IMGNAME \
     ./_build.sh $REV
 ) || fail "Build inside docker container failed"

--- a/contrib/build-wine/deterministic.spec
+++ b/contrib/build-wine/deterministic.spec
@@ -10,7 +10,7 @@ for i, x in enumerate(sys.argv):
 else:
     raise BaseException('no name')
 
-home = 'C:\\electroncash\\'
+home = 'C:\\electrumbcha\\'
 
 # see https://github.com/pyinstaller/pyinstaller/issues/2005
 hiddenimports = []
@@ -65,7 +65,7 @@ datas += collect_data_files('keepkeylib')
 datas += collect_data_files('mnemonic')  # wordlists used by keepkeylib from lib mnemonic
 
 # We don't put these files in to actually include them in the script but to make the Analysis method scan them for imports
-a = Analysis([home+'electron-cash',
+a = Analysis([home+'electrum-bcha',
               home+'electroncash_gui/qt/main_window.py',
               home+'electroncash_gui/qt/qrreader/camera_dialog.py',
               home+'electroncash_gui/text.py',

--- a/contrib/build-wine/docker/Dockerfile
+++ b/contrib/build-wine/docker/Dockerfile
@@ -45,4 +45,4 @@ RUN rm -rf /var/lib/apt/lists/* && \
 ARG USER_ID
 ARG GROUP_ID
 
-RUN mkdir -p /homedir/wine64/drive_c/electroncash ; chown -R ${USER_ID}:${GROUP_ID} /homedir && ls -al /homedir
+RUN mkdir -p /homedir/wine64/drive_c/electrumbcha ; chown -R ${USER_ID}:${GROUP_ID} /homedir && ls -al /homedir

--- a/contrib/build-wine/electron-cash.nsi
+++ b/contrib/build-wine/electron-cash.nsi
@@ -6,10 +6,10 @@
 ;--------------------------------
 ;Variables
 
-  !define PRODUCT_NAME "Electron Cash"
-  !define INTERNAL_NAME "Electron-Cash"
-  !define PRODUCT_WEB_SITE "https://github.com/Electron-Cash/Electron-Cash"
-  !define PRODUCT_PUBLISHER "Electron Cash LLC"
+  !define PRODUCT_NAME "Electrum BCHA"
+  !define INTERNAL_NAME "Electrum-BCHA"
+  !define PRODUCT_WEB_SITE "https://github.com/PiRK/ElectrumBCHA"
+  !define PRODUCT_PUBLISHER "Bitcoin ABC"
   !define PRODUCT_UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}"
 
 ;--------------------------------
@@ -73,7 +73,7 @@
   !define MUI_ABORTWARNING
   !define MUI_ABORTWARNING_TEXT "Are you sure you wish to abort the installation of ${PRODUCT_NAME}?"
 
-  !define MUI_ICON "\electroncash\icons\electron.ico"
+  !define MUI_ICON "\electrumbcha\icons\electron.ico"
 
 ;--------------------------------
 ;Pages

--- a/electroncash/__init__.py
+++ b/electroncash/__init__.py
@@ -13,3 +13,4 @@ from .plugins import BasePlugin
 from .commands import Commands, known_commands
 from . import address
 from . import cashacct  # has a side-effect: registers itself with ScriptOut protocol system
+

--- a/electroncash/base_wizard.py
+++ b/electroncash/base_wizard.py
@@ -34,6 +34,7 @@ from . import util
 from .wallet import (ImportedAddressWallet, ImportedPrivkeyWallet,
                      Standard_Wallet, Multisig_Wallet, wallet_types)
 from .i18n import _
+from .constants import PROJECT_NAME
 
 
 class BaseWizard(util.PrintError):
@@ -466,5 +467,5 @@ class BaseWizard(util.PrintError):
             self.wallet.synchronize()
             self.wallet.storage.write()
             self.terminate()
-        msg = _("Electron Cash is generating your addresses, please wait.")
+        msg = _(f"{PROJECT_NAME} is generating your addresses, please wait.")
         self.waiting_dialog(task, msg)

--- a/electroncash/bitcoin.py
+++ b/electroncash/bitcoin.py
@@ -35,6 +35,7 @@ import pyaes
 
 from typing import Tuple
 
+from .constants import PROJECT_NAME
 from . import networks
 from .util import (bfh, bh2u, to_string, print_error, InvalidPassword,
                    assert_bytes, to_bytes, inv_dict, profiler)
@@ -49,8 +50,9 @@ except AssertionError:
     pass
 else:
     import sys
-    sys.exit('Electron Cash uses "assert" statements for its normal control flow.\n'
-             'Please run this application without the python "-O" (optimize) flag.')
+    sys.exit(f'{PROJECT_NAME} uses "assert" statements for its normal control'
+             f' flow.\nPlease run this application without the python "-O" '
+             f'(optimize) flag.')
 # /End -O check
 
 do_monkey_patching_of_python_ecdsa_internals_with_libsecp256k1()

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -38,6 +38,7 @@ from functools import wraps
 from . import bitcoin
 from . import rpa
 from . import util
+from .constants import PROJECT_NAME, SCRIPT_NAME
 from .address import Address, AddressError
 from .bitcoin import hash_160, COIN, TYPE_ADDRESS
 from .i18n import _
@@ -98,7 +99,8 @@ def command(s):
             if c.requires_network and network is None:
                 raise BaseException("Daemon offline")  # Same wording as in daemon.py.
             if c.requires_wallet and wallet is None:
-                raise BaseException("Wallet not loaded. Use 'electron-cash daemon load_wallet'")
+                raise BaseException(f"Wallet not loaded. Use '{SCRIPT_NAME}"
+                                    f" daemon load_wallet'")
             if c.requires_password and password is None and wallet.storage.get('use_encryption') \
                and not kwargs.get("unsigned"):
                 return {'error': 'Password required' }
@@ -393,7 +395,9 @@ class Commands:
     @command('')
     def dumpprivkeys(self):
         """Deprecated."""
-        return "This command is deprecated. Use a pipe instead: 'electron-cash listaddresses | electron-cash getprivatekeys - '"
+        return f"This command is deprecated. Use a pipe instead: " \
+               f"'{SCRIPT_NAME} listaddresses | {SCRIPT_NAME} " \
+               f"getprivatekeys - '"
 
     @command('')
     def validateaddress(self, address):
@@ -1000,7 +1004,7 @@ def add_network_options(parser):
 def add_global_options(parser):
     group = parser.add_argument_group('global options')
     group.add_argument("-v", "--verbose", action="store_true", dest="verbose", default=False, help="Show debugging information")
-    group.add_argument("-D", "--dir", dest="electron_cash_path", help="electron cash directory")
+    group.add_argument("-D", "--dir", dest="electrum_bcha_path", help=f"{PROJECT_NAME} directory")
     group.add_argument("-P", "--portable", action="store_true", dest="portable", default=False, help="Use local 'electron_cash_data' directory")
     group.add_argument("-w", "--wallet", dest="wallet_path", help="wallet path")
     group.add_argument("-wp", "--walletpassword", dest="wallet_password", default=None, help="Supply wallet password")
@@ -1011,11 +1015,11 @@ def add_global_options(parser):
 def get_parser():
     # create main parser
     parser = argparse.ArgumentParser(
-        epilog="Run 'electron-cash help <command>' to see the help for a command")
+        epilog=f"Run '{SCRIPT_NAME} help <command>' to see the help for a command")
     add_global_options(parser)
     subparsers = parser.add_subparsers(dest='cmd', metavar='<command>')
     # gui
-    parser_gui = subparsers.add_parser('gui', description="Run Electron Cash's Graphical User Interface.", help="Run GUI (default)")
+    parser_gui = subparsers.add_parser('gui', description=f"Run {PROJECT_NAME}'s Graphical User Interface.", help="Run GUI (default)")
     parser_gui.add_argument("url", nargs='?', default=None, help="bitcoin URI (or bip70 file)")
     parser_gui.add_argument("-g", "--gui", dest="gui", help="select graphical user interface", choices=['qt', 'text', 'stdio'])
     parser_gui.add_argument("-o", "--offline", action="store_true", dest="offline", default=False, help="Run offline")

--- a/electroncash/constants.py
+++ b/electroncash/constants.py
@@ -1,0 +1,2 @@
+PROJECT_NAME: str = "Electrum BCHA"
+SCRIPT_NAME: str = "electrum-bcha"

--- a/electroncash/daemon.py
+++ b/electroncash/daemon.py
@@ -27,6 +27,8 @@ import os
 import time
 import sys
 
+from .constants import PROJECT_NAME, SCRIPT_NAME
+
 # from jsonrpc import JSONRPCResponseManager
 import jsonrpclib
 from .jsonrpc import VerifyingJSONRPCServer
@@ -70,7 +72,7 @@ def get_fd_or_server(config):
             sys.exit(f"Unable to create lockfile due to file system permission problems: {e}")
         except NotADirectoryError as e:
             lockdir = os.path.dirname(lockfile)
-            sys.exit(f"Electron Cash directory location at {lockdir} is not a directory. Error was: {e}")
+            sys.exit(f"{PROJECT_NAME} directory location at {lockdir} is not a directory. Error was: {e}")
         except OSError as e:
             ''' Unable to create -- this is normal if there was a pre-existing lockfile '''
             latest_exc = e
@@ -245,7 +247,7 @@ class Daemon(DaemonThread):
             else:
                 response = "error: current GUI does not support multiple windows"
         else:
-            response = "Error: Electron Cash is running in daemon mode. Please stop the daemon first."
+            response = f"Error: {PROJECT_NAME} is running in daemon mode. Please stop the daemon first."
         return response
 
     def load_wallet(self, path, password):
@@ -303,7 +305,8 @@ class Daemon(DaemonThread):
             path = config.get_wallet_path()
             wallet = self.wallets.get(path)
             if wallet is None:
-                return {'error': 'Wallet "%s" is not loaded. Use "electron-cash daemon load_wallet"'%os.path.basename(path) }
+                wallet_name = os.path.basename(path)
+                return {'error': f'Wallet "{wallet_name}" is not loaded. Use "{SCRIPT_NAME} daemon load_wallet"'}
         else:
             wallet = None
         # arguments passed to function

--- a/electroncash/exchange_rate.py
+++ b/electroncash/exchange_rate.py
@@ -42,7 +42,7 @@ class ExchangeBase(PrintError):
     def get_json(self, site, get_string):
         # APIs must have https
         url = ''.join(['https://', site, get_string])
-        response = requests.request('GET', url, headers={'User-Agent' : 'Electron Cash'}, timeout=10)
+        response = requests.request('GET', url, headers={'User-Agent': 'Electron Cash'}, timeout=10)
         if response.status_code != 200:
             raise RuntimeWarning("Response status: " + str(response.status_code))
         return response.json()

--- a/electroncash/paymentrequest.py
+++ b/electroncash/paymentrequest.py
@@ -46,6 +46,7 @@ from . import util
 from . import transaction
 from . import x509
 from . import rsakey
+from .constants import PROJECT_NAME
 
 from .address import Address, PublicKey
 from .bitcoin import TYPE_ADDRESS
@@ -299,7 +300,7 @@ class PaymentRequest:
         paymnt.transactions.append(bfh(raw_tx))
         ref_out = paymnt.refund_to.add()
         ref_out.script = bfh(transaction.Transaction.pay_script(refund_addr))
-        paymnt.memo = "Paid using Electron Cash"
+        paymnt.memo = f"Paid using {PROJECT_NAME}"
         pm = paymnt.SerializeToString()
         payurl = urllib.parse.urlparse(pay_det.payment_url)
         try:

--- a/electroncash/plugins.py
+++ b/electroncash/plugins.py
@@ -39,6 +39,7 @@ from typing import Callable, Optional
 
 from . import bitcoin
 from . import version
+from .constants import PROJECT_NAME, SCRIPT_NAME
 from .i18n import _
 from .util import (print_error, print_stderr, make_dir, profiler, user_dir,
                    DaemonThread, PrintError, ThreadJob, UserCancelled)
@@ -611,7 +612,7 @@ def run_hook(name, *args, **kwargs):
         return results[0]
 
 def daemon_command(func):
-    """ Method decorator for BasePlugin subclasses to add a remote command
+    f""" Method decorator for BasePlugin subclasses to add a remote command
     to the daemon. Usage:
 
         class MyPlugin(BasePlugin):
@@ -624,7 +625,7 @@ def daemon_command(func):
 
     These can then be invoked as:
 
-        ./electron-cash daemon myplugin_action1 arg arg arg ...
+        ./{SCRIPT_NAME} daemon myplugin_action1 arg arg arg ...
 
     Here `config` is *not* the usual global config but also includes the options
     from the command line client:
@@ -911,11 +912,11 @@ class DeviceMgr(ThreadJob):
         # The user input has wrong PIN or passphrase, or cancelled input,
         # or it is not pairable
         raise DeviceUnpairableError(
-            _('Electron Cash cannot pair with your {}.\n\n'
+            _(f'{PROJECT_NAME} cannot pair with your {plugin.device}.\n\n'
               'Before you request bitcoins to be sent to addresses in this '
               'wallet, ensure you can pair with your device, or that you have '
               'its seed (and passphrase, if any).  Otherwise all bitcoins you '
-              'receive will be unspendable.').format(plugin.device))
+              'receive will be unspendable.'))
 
     def unpaired_device_infos(self, handler, plugin, devices=None):
         '''Returns a list of DeviceInfo objects: one for each connected,

--- a/electroncash/simple_config.py
+++ b/electroncash/simple_config.py
@@ -7,6 +7,7 @@ import stat
 from . import util
 from copy import deepcopy
 from .util import user_dir, make_dir, print_error, PrintError
+from .constants import SCRIPT_NAME
 
 from .bitcoin import MAX_FEE_RATE, FEE_TARGETS
 
@@ -88,7 +89,7 @@ class SimpleConfig(PrintError):
     def electrum_path(self):
         # Read electrum_cash_path from command line
         # Otherwise use the user's default data directory.
-        path = self.get('electron_cash_path')
+        path = self.get('electrum_bcha_path')
         if path is None:
             path = self.user_dir()
 
@@ -106,7 +107,7 @@ class SimpleConfig(PrintError):
         obsolete_file = os.path.join(path, 'recent_servers')
         if os.path.exists(obsolete_file):
             os.remove(obsolete_file)
-        self.print_error("electron-cash directory", path)
+        self.print_error(f"{SCRIPT_NAME} directory", path)
         return path
 
     def rename_config_keys(self, config, keypairs, deprecation_warning=False):

--- a/electroncash/tests/test_simple_config.py
+++ b/electroncash/tests/test_simple_config.py
@@ -19,7 +19,7 @@ class Test_SimpleConfig(unittest.TestCase):
         # for development machines with electrum installed :)
         self.user_dir = tempfile.mkdtemp()
 
-        self.options = {"electron_cash_path": self.electrum_dir}
+        self.options = {"electrum_bcha_path": self.electrum_dir}
         self._saved_stdout = sys.stdout
         self._stdout_buffer = StringIO()
         sys.stdout = self._stdout_buffer
@@ -53,44 +53,44 @@ class Test_SimpleConfig(unittest.TestCase):
     def test_simple_config_command_line_overrides_everything(self):
         """Options passed by command line override all other configuration
         sources"""
-        fake_read_user = lambda _: {"electron_cash_path": "b"}
+        fake_read_user = lambda _: {"electrum_bcha_path": "b"}
         read_user_dir = lambda : self.user_dir
         config = SimpleConfig(options=self.options,
                               read_user_config_function=fake_read_user,
                               read_user_dir_function=read_user_dir)
-        self.assertEqual(self.options.get("electron_cash_path"),
-                         config.get("electron_cash_path"))
+        self.assertEqual(self.options.get("electrum_bcha_path"),
+                         config.get("electrum_bcha_path"))
 
     def test_simple_config_user_config_is_used_if_others_arent_specified(self):
         """If no system-wide configuration and no command-line options are
         specified, the user configuration is used instead."""
-        fake_read_user = lambda _: {"electron_cash_path": self.electrum_dir}
+        fake_read_user = lambda _: {"electrum_bcha_path": self.electrum_dir}
         read_user_dir = lambda : self.user_dir
         config = SimpleConfig(options={},
                               read_user_config_function=fake_read_user,
                               read_user_dir_function=read_user_dir)
-        self.assertEqual(self.options.get("electron_cash_path"),
-                         config.get("electron_cash_path"))
+        self.assertEqual(self.options.get("electrum_bcha_path"),
+                         config.get("electrum_bcha_path"))
 
     def test_cannot_set_options_passed_by_command_line(self):
-        fake_read_user = lambda _: {"electron_cash_path": "b"}
+        fake_read_user = lambda _: {"electrum_bcha_path": "b"}
         read_user_dir = lambda : self.user_dir
         config = SimpleConfig(options=self.options,
                               read_user_config_function=fake_read_user,
                               read_user_dir_function=read_user_dir)
-        config.set_key("electron_cash_path", "c")
-        self.assertEqual(self.options.get("electron_cash_path"),
-                         config.get("electron_cash_path"))
+        config.set_key("electrum_bcha_path", "c")
+        self.assertEqual(self.options.get("electrum_bcha_path"),
+                         config.get("electrum_bcha_path"))
 
     def test_can_set_options_set_in_user_config(self):
         another_path = tempfile.mkdtemp()
-        fake_read_user = lambda _: {"electron_cash_path": self.electrum_dir}
+        fake_read_user = lambda _: {"electrum_bcha_path": self.electrum_dir}
         read_user_dir = lambda : self.user_dir
         config = SimpleConfig(options={},
                               read_user_config_function=fake_read_user,
                               read_user_dir_function=read_user_dir)
-        config.set_key("electron_cash_path", another_path)
-        self.assertEqual(another_path, config.get("electron_cash_path"))
+        config.set_key("electrum_bcha_path", another_path)
+        self.assertEqual(another_path, config.get("electrum_bcha_path"))
 
     def test_user_config_is_not_written_with_read_only_config(self):
         """The user config does not contain command-line options when saved."""

--- a/electroncash/tests/test_storage_upgrade.py
+++ b/electroncash/tests/test_storage_upgrade.py
@@ -260,7 +260,7 @@ class TestStorageUpgrade(WalletTestCase):
         from ..simple_config import SimpleConfig
 
         cls.electron_cash_path = tempfile.mkdtemp()
-        config = SimpleConfig({'electron_cash_path': cls.electron_cash_path})
+        config = SimpleConfig({'electrum_bcha_path': cls.electron_cash_path})
 
         gui_name = 'cmdline'
         # TODO it's probably wasteful to load all plugins... only need Trezor

--- a/electroncash/tests/test_wallet.py
+++ b/electroncash/tests/test_wallet.py
@@ -27,7 +27,7 @@ class WalletTestCase(unittest.TestCase):
     def setUp(self):
         super(WalletTestCase, self).setUp()
         self.user_dir = tempfile.mkdtemp()
-        self.config = SimpleConfig({'electron_cash_path': self.user_dir})
+        self.config = SimpleConfig({'electrum_bcha_path': self.user_dir})
 
         self.wallet_path = os.path.join(self.user_dir, "somewallet")
 

--- a/electroncash_gui/qt/__init__.py
+++ b/electroncash_gui/qt/__init__.py
@@ -62,6 +62,7 @@ from electroncash.util import (UserCancelled, PrintError, print_error,
                                get_new_wallet_name, Handlers)
 from electroncash import version
 from electroncash.address import Address
+from electroncash.constants import PROJECT_NAME
 
 from .installwizard import InstallWizard, GoBack
 
@@ -71,6 +72,7 @@ from .main_window import ElectrumWindow
 from .network_dialog import NetworkDialog
 from .exception_window import Exception_Hook
 from .update_checker import UpdateChecker
+
 
 
 class ElectrumGui(QObject, PrintError):
@@ -139,7 +141,7 @@ class ElectrumGui(QObject, PrintError):
         # init tray
         self.dark_icon = self.config.get("dark_icon", False)
         self.tray = QSystemTrayIcon(self.tray_icon(), self)
-        self.tray.setToolTip('Electron Cash')
+        self.tray.setToolTip(f'{PROJECT_NAME}')
         self.tray.activated.connect(self.tray_activated)
         self.build_tray_menu()
         self.tray.show()
@@ -463,11 +465,11 @@ class ElectrumGui(QObject, PrintError):
 
     def _check_and_warn_qt_version(self):
         if sys.platform == 'linux' and self.qt_version() < (5, 12):
-            msg = _("Electron Cash on Linux requires PyQt5 5.12+.\n\n"
-                    "You have version {version_string} installed.\n\n"
+            msg = _(f"{PROJECT_NAME} on Linux requires PyQt5 5.12+.\n\n"
+                    f"You have version {QT_VERSION_STR} installed.\n\n"
                     "Please upgrade otherwise you may experience "
                     "font rendering issues with emojis and other unicode "
-                    "characters used by Electron Cash.").format(version_string=QT_VERSION_STR)
+                    f"characters used by {PROJECT_NAME}.")
             QMessageBox.warning(None, _("PyQt5 Upgrade Needed"), msg)  # this works even if app is not exec_() yet.
 
 
@@ -503,7 +505,7 @@ class ElectrumGui(QObject, PrintError):
         m.addSeparator()
         m.addAction(_("&Check for updates..."), lambda: self.show_update_checker(None))
         m.addSeparator()
-        m.addAction(_("Exit Electron Cash"), self.close)
+        m.addAction(_(f"Exit {PROJECT_NAME}"), self.close)
         self.tray.setContextMenu(m)
 
     def tray_icon(self):
@@ -721,7 +723,7 @@ class ElectrumGui(QObject, PrintError):
         to the system tray. '''
         self.new_version_available = newver
         self.update_available_signal.emit(True)
-        self.notify(_("A new version of Electron Cash is available: {}").format(newver))
+        self.notify(_(f"A new version of {PROJECT_NAME} is available: {newver}"))
 
     def show_update_checker(self, parent, *, skip_check = False):
         if self.warn_if_no_network(parent):
@@ -773,7 +775,10 @@ class ElectrumGui(QObject, PrintError):
 
     def warn_if_no_network(self, parent):
         if not self.daemon.network:
-            self.warning(message=_('You are using Electron Cash in offline mode; restart Electron Cash if you want to get connected'), title=_('Offline'), parent=parent, rich_text=True)
+            self.warning(message=_(f'You are using {PROJECT_NAME} in offline '
+                                   f'mode; restart {PROJECT_NAME} if you want '
+                                   f'to get connected'),
+                         title=_('Offline'), parent=parent, rich_text=True)
             return True
         return False
 
@@ -796,21 +801,22 @@ class ElectrumGui(QObject, PrintError):
 
         # else..
         howto_url='https://github.com/Electron-Cash/Electron-Cash/blob/master/contrib/secp_HOWTO.md#libsecp256k1-0-for-electron-cash'
-        template = '''
+        message = message or _(
+            f"{PROJECT_NAME} was unable to find the secp256k1 library on this "
+            f"system. Elliptic curve cryptography operations will be performed"
+            f" in slow Python-only mode."),
+        url_blurb = _("Please visit this page for instructions on how to "
+                      "correct the situation:")
+        msg = f'''
         <html><body>
             <p>
             {message}
             <p>
             {url_blurb}
             </p>
-            <p><a href="{url}">Electron Cash Secp Mini-HOWTO</a></p>
+            <p><a href="{howto_url}">{PROJECT_NAME} Secp Mini-HOWTO</a></p>
         </body></html>
         '''
-        msg = template.format(
-            message = message or _("Electron Cash was unable to find the secp256k1 library on this system. Elliptic curve cryptography operations will be performed in slow Python-only mode."),
-            url=howto_url,
-            url_blurb = _("Please visit this page for instructions on how to correct the situation:")
-        )
         self.warning(parent=parent, title=_("Missing libsecp256k1"),
                      message=msg, rich_text=True)
         return True
@@ -856,13 +862,29 @@ class ElectrumGui(QObject, PrintError):
             # the future -- it only appears on first-run if key was None
             self.config.set_key('qt_enable_highdpi', True)
             if is_lin:
-                msg = (_("Automatic high DPI scaling has been enabled for Electron Cash, which should result in improved graphics quality.")
-                       + "\n\n" + _("However, on some esoteric Linux systems, this mode may cause disproportionately large status bar icons.")
-                       + "\n\n" + _("If that is the case for you, then you may disable automatic DPI scaling in the preferences, under 'General'."))
+                msg = (_(f"Automatic high DPI scaling has been enabled for "
+                         f"{PROJECT_NAME}, which should result in improved "
+                         f"graphics quality.")
+                       + "\n\n"
+                       + _("However, on some esoteric Linux systems, this "
+                           "mode may cause disproportionately large status "
+                           "bar icons.")
+                       + "\n\n"
+                       + _("If that is the case for you, then you may disable"
+                           " automatic DPI scaling in the preferences, under "
+                           "'General'."))
             else: # is_win
-                msg = (_("Automatic high DPI scaling has been enabled for Electron Cash, which should result in improved graphics quality.")
-                       + "\n\n" + _("However, on some Windows systems, bugs in Qt may result in minor graphics glitches in system 'message box' dialogs.")
-                       + "\n\n" + _("If that is the case for you, then you may disable automatic DPI scaling in the preferences, under 'General'."))
+                msg = (_(f"Automatic high DPI scaling has been enabled for "
+                         f"{PROJECT_NAME}, which should result in improved "
+                         f"graphics quality.")
+                       + "\n\n"
+                       + _("However, on some Windows systems, bugs in Qt may "
+                           "result in minor graphics glitches in system "
+                           "'message box' dialogs.")
+                       + "\n\n"
+                       + _("If that is the case for you, then you may disable "
+                           "automatic DPI scaling in the preferences, under "
+                           "'General'."))
             parent.show_message( title = _('Automatic High DPI'), msg = msg)
 
     def has_auto_update_check(self):
@@ -896,9 +918,12 @@ class ElectrumGui(QObject, PrintError):
         if self.tray:
             try:
                 # this requires Qt 5.9
-                self.tray.showMessage("Electron Cash", message, QIcon(":icons/electron-cash.svg"), 20000)
+                self.tray.showMessage(f"{PROJECT_NAME}", message,
+                                      QIcon(":icons/electron-cash.svg"),
+                                      20000)
             except TypeError:
-                self.tray.showMessage("Electron Cash", message, QSystemTrayIcon.Information, 20000)
+                self.tray.showMessage(f"{PROJECT_NAME}", message,
+                                      QSystemTrayIcon.Information, 20000)
 
     def is_cashaddr(self):
         return bool(self.config.get('show_cashaddr', True))

--- a/electroncash_gui/qt/bip38_importer.py
+++ b/electroncash_gui/qt/bip38_importer.py
@@ -12,6 +12,8 @@ from .util import *
 from electroncash.i18n import _
 from electroncash import util, bitcoin, address
 
+from electroncash.constants import PROJECT_NAME
+
 class Bip38Importer(WindowModalDialog, util.PrintError):
     ''' A drop-in GUI element for implementing a BIP38 import dialog.
     For each of the passed-in bip38 keys, it will prompt the user to enter their
@@ -45,7 +47,7 @@ class Bip38Importer(WindowModalDialog, util.PrintError):
         decrypted or a user cancel.
         '''
         if not title:
-            title = 'Electron Cash - ' + _('BIP38 Import')
+            title = f'{PROJECT_NAME} - ' + _('BIP38 Import')
         WindowModalDialog.__init__(self, parent=parent, title=title)
         if not bitcoin.is_bip38_available():
             raise RuntimeError('Bip38Importer: bip38 decoding is not available')

--- a/electroncash_gui/qt/cashacctqt.py
+++ b/electroncash_gui/qt/cashacctqt.py
@@ -44,6 +44,7 @@ from electroncash import web
 from electroncash.address import Address, UnknownAddress
 from electroncash.i18n import _, ngettext
 from electroncash.wallet import Abstract_Wallet
+from electroncash.constants import PROJECT_NAME
 
 
 class VerifyingDialog(WaitingDialog):
@@ -165,8 +166,8 @@ def resolve_cashacct(parent : MessageBoxMixin, name : str, wallet : Abstract_Wal
         name = wallet.cashacct.fmt_info(info, mch)
         if not isinstance(info.address, Address):
             raise Bad(_("Unsupported payment data type.") + "\n\n"
-                      + _("The Cash Account {name} uses an account type that "
-                          "is not supported by Electron Cash.").format(name=name))
+                      + _(f"The Cash Account {name} uses an account type that "
+                          f"is not supported by {PROJECT_NAME}."))
         return info, name
     except Bad as e:
         parent.show_error(str(e))
@@ -399,7 +400,7 @@ class InfoGroupBox(PrintError, QGroupBox):
             if not isinstance(info.address, Address):
                 rb.setDisabled(True)
                 is_valid = False
-                rb.setToolTip(_('Electron Cash currently only supports Cash Account types 1 & 2'))
+                rb.setToolTip(_(f'{PROJECT_NAME} currently only supports Cash Account types 1 & 2'))
             elif wallet.is_mine(info.address):
                 is_mine = True
                 is_change = wallet.is_change(info.address)
@@ -584,7 +585,10 @@ def lookup_cash_account_dialog(
 
 
     #acct.setFixedWidth(280)
-    label = HelpLabel(_("&Cash Account Name"), _("Enter a Cash Account name of the form Name#123.45, and Electron Cash will search for the contact and present you with its resolved address."))
+    label = HelpLabel(_("&Cash Account Name"),
+                      _(f"Enter a Cash Account name of the form Name#123.45, "
+                        f"and {PROJECT_NAME} will search for the contact and "
+                        f"present you with its resolved address."))
     label.setBuddy(acct)
     search = QPushButton(_("Lookup"))
     search.setEnabled(False)
@@ -779,8 +783,8 @@ def cash_account_detail_dialog(parent : MessageBoxMixin,  # Should be an Electru
     # file assumes info.address is an Address.
     if not isinstance(info.address, Address):
         parent.show_error(_("Unsupported payment data type.") + "\n\n"
-                          + _("The Cash Account {name} uses an account type that "
-                              "is not supported by Electron Cash.").format(name=ca_string))
+                          + _(f"The Cash Account {ca_string} uses an account "
+                              f"type that is not supported by {PROJECT_NAME}."))
         return False
 
     title = title or _("Cash Account Details")

--- a/electroncash_gui/qt/contact_list.py
+++ b/electroncash_gui/qt/contact_list.py
@@ -29,6 +29,7 @@ from electroncash.address import Address
 from electroncash.contacts import Contact, contact_types
 from electroncash.plugins import run_hook
 from electroncash.util import FileImportFailed, PrintError, finalization_print_error
+from electroncash.constants import PROJECT_NAME
 # TODO: whittle down these * imports to what we actually use when done with
 # our changes to this class -Calin
 from PyQt5.QtGui import *
@@ -131,7 +132,9 @@ class ContactList(PrintError, MyTreeWidget):
             num = self.parent.contacts.import_file(filename)
             self.parent.show_message(_("{} contacts successfully imported.").format(num))
         except Exception as e:
-            self.parent.show_error(_("Electron Cash was unable to import your contacts.") + "\n" + repr(e))
+            self.parent.show_error(
+                _(f"{PROJECT_NAME} was unable to import your contacts.")
+                + "\n" + repr(e))
         self.on_update()
 
     def export_contacts(self):
@@ -144,7 +147,9 @@ class ContactList(PrintError, MyTreeWidget):
                 num = self.parent.contacts.export_file(fileName)
                 self.parent.show_message(_("{} contacts exported to '{}'").format(num, fileName))
         except Exception as e:
-            self.parent.show_error(_("Electron Cash was unable to export your contacts.") + "\n" + repr(e))
+            self.parent.show_error(
+                _(f"{PROJECT_NAME} was unable to export your contacts.")
+                + "\n" + repr(e))
 
     def find_item(self, key: Contact) -> QTreeWidgetItem:
         ''' Rather than store the item reference in a lambda, we store its key.

--- a/electroncash_gui/qt/exception_window.py
+++ b/electroncash_gui/qt/exception_window.py
@@ -39,6 +39,7 @@ from electroncash.i18n import _
 import sys
 from electroncash import PACKAGE_VERSION
 from electroncash.util import print_error, finalization_print_error
+from electroncash.constants import PROJECT_NAME
 from .main_window import ElectrumWindow
 from .util import destroyed_print_error
 
@@ -50,13 +51,13 @@ issue_template = """<h2>Traceback</h2>
 
 <h2>Additional information</h2>
 <ul>
-  <li>Electron Cash version: {app_version}</li>
+  <li>%s version: {app_version}</li>
   <li>Python version: {python_version}</li>
   <li>Operating system: {os}</li>
   <li>Wallet type: {wallet_type}</li>
   <li>Locale: {locale}</li>
 </ul>
-"""
+""" % PROJECT_NAME
 report_server = "https://crashhub.electroncash.org/crash"
 
 
@@ -67,7 +68,7 @@ class Exception_Window(QWidget):
         super().__init__(None) # Top-level window. Note PyQt top level windows are kept alive by strong references, hence _active_window
         self.exc_args = (exctype, value, tb)
         self.config = config
-        self.setWindowTitle('Electron Cash - ' + _('An Error Occurred'))
+        self.setWindowTitle(f'{PROJECT_NAME} - ' + _('An Error Occurred'))
         self.setMinimumSize(600, 300)
 
         main_box = QVBoxLayout()
@@ -75,7 +76,7 @@ class Exception_Window(QWidget):
 
         heading = QLabel('<h2>' + _('Sorry!') + '</h2>')
         main_box.addWidget(heading)
-        l = QLabel(_('Something went wrong running Electron Cash.'))
+        l = QLabel(_(f'Something went wrong running {PROJECT_NAME}.'))
         l.setWordWrap(True)
         main_box.addWidget(l)
 

--- a/electroncash_gui/qt/external_plugins_window.py
+++ b/electroncash_gui/qt/external_plugins_window.py
@@ -33,21 +33,31 @@ from PyQt5.QtWidgets import *
 
 from electroncash.i18n import _
 from electroncash.plugins import ExternalPluginCodes, run_hook
+from electroncash.constants import PROJECT_NAME
 from .util import MyTreeWidget, MessageBoxMixin, WindowModalDialog, Buttons, CloseButton
 
 
 INSTALL_ERROR_MESSAGES = {
     ExternalPluginCodes.MISSING_MANIFEST: _("The plugin archive you selected is missing a manifest. It was therefore not possible to install it."),
     ExternalPluginCodes.NAME_ALREADY_IN_USE: _("There is already a plugin installed using the internal package name of the plugin you selected. It was therefore not possible to install it."),
-    ExternalPluginCodes.UNABLE_TO_COPY_FILE: _("It was not possible to copy the plugin archive into Electron Cash's plugin storage location. It was therefore not possible to install it."),
-    ExternalPluginCodes.INSTALLED_BUT_FAILED_LOAD: _("The plugin is installed, but in the process of enabling and loading it, an error occurred. Restart Electron Cash and try again, or uninstall it and report it to it's developers."),
-    ExternalPluginCodes.INCOMPATIBLE_VERSION: _("The plugin is targeted at a later version of Electron Cash."),
+    ExternalPluginCodes.UNABLE_TO_COPY_FILE:
+        _(f"It was not possible to copy the plugin archive into "
+          f"{PROJECT_NAME}'s plugin storage location. It was "
+          f"therefore not possible to install it."),
+    ExternalPluginCodes.INSTALLED_BUT_FAILED_LOAD:
+        _("The plugin is installed, but in the process of enabling "
+          f"and loading it, an error occurred. Restart {PROJECT_NAME} and"
+          f" try again, or uninstall it and report it to it's developers."),
+    ExternalPluginCodes.INCOMPATIBLE_VERSION:
+        _(f"The plugin is targeted at a later version of {PROJECT_NAME}."),
     ExternalPluginCodes.INCOMPATIBLE_ZIP_FORMAT: _("The plugin archive is not recognized as a valid Zip file."),
     ExternalPluginCodes.INVALID_MANIFEST_JSON: _("The plugin manifest is not recognized as valid JSON."),
     ExternalPluginCodes.INVALID_MAMIFEST_DISPLAY_NAME: _("The plugin manifest lacks a valid display name."),
     ExternalPluginCodes.INVALID_MAMIFEST_DESCRIPTION: _("The plugin manifest lacks a valid description."),
     ExternalPluginCodes.INVALID_MAMIFEST_VERSION: _("The plugin manifest lacks a valid version."),
-    ExternalPluginCodes.INVALID_MAMIFEST_MINIMUM_EC_VERSION: _("The plugin manifest lacks a valid minimum Electron Cash version."),
+    ExternalPluginCodes.INVALID_MAMIFEST_MINIMUM_EC_VERSION:
+        _(f"The plugin manifest lacks a valid minimum {PROJECT_NAME} "
+          f"version."),
     ExternalPluginCodes.INVALID_MAMIFEST_PACKAGE_NAME: _("The plugin manifest lacks a valid package name."),
     ExternalPluginCodes.UNSPECIFIED_ERROR: _("An unspecified exception was raised. Cannot open plugin.")
 }
@@ -116,7 +126,9 @@ class ExternalPluginsPreviewDialog(WindowModalDialog):
             confirmGroupBox = QGroupBox(_("Risks and Dangers"))
             liabilityLabel = QLabel(_("I accept responsibility for any harm that comes from installing this plugin, and acknowledge:"))
             rows = QVBoxLayout()
-            self.liabilityCheckbox1 = QCheckBox(_("The Electron Cash Developers do NOT audit or vet any plugins."))
+            self.liabilityCheckbox1 = QCheckBox(
+                _(f"The {PROJECT_NAME} Developers do NOT audit or vet "
+                  f"any plugins."))
             self.liabilityCheckbox2 = QCheckBox(_("Plugins are risky.  They can steal funds or even damage your computer."))
             self.liabilityCheckbox3 = QCheckBox(_("I should only install the most reputable plugins trusted by the community."))
             confirmLayout.addWidget(liabilityLabel)
@@ -264,7 +276,9 @@ class ExternalPluginsDialog(WindowModalDialog, MessageBoxMixin):
         self.descriptionGroupBox.setAlignment(Qt.AlignHCenter)
         descriptionGroupLayout = QVBoxLayout()
         self.descriptionGroupBox.setLayout(descriptionGroupLayout)
-        self.descriptionLabel = QLabel(_("Install plugins at your own risk.\nThey have almost complete access to Electron Cash's internals."))
+        self.descriptionLabel = QLabel(
+            _(f"Install plugins at your own risk.\nThey have almost complete"
+              f" access to {PROJECT_NAME}'s internals."))
         self.descriptionLabel.setAlignment(Qt.AlignCenter)
         descriptionGroupLayout.addWidget(self.descriptionLabel)
         vbox.addWidget(self.descriptionGroupBox)

--- a/electroncash_gui/qt/installwizard.py
+++ b/electroncash_gui/qt/installwizard.py
@@ -12,6 +12,7 @@ from electroncash import Wallet, WalletStorage
 from electroncash.util import UserCancelled, InvalidPassword, finalization_print_error
 from electroncash.base_wizard import BaseWizard
 from electroncash.i18n import _
+from electroncash.constants import PROJECT_NAME
 
 from .seed_dialog import SeedLayout, KeysLayout
 from .network_dialog import NetworkChoiceLayout
@@ -23,7 +24,7 @@ from .bip38_importer import Bip38Importer
 class GoBack(Exception):
     pass
 
-MSG_GENERATING_WAIT = _("Electron Cash is generating your addresses, please wait...")
+MSG_GENERATING_WAIT = _(f"{PROJECT_NAME} is generating your addresses, please wait...")
 MSG_ENTER_ANYTHING = _("Please enter a seed phrase, a master key, a list of "
                        "Bitcoin addresses, or a list of private keys")
 MSG_ENTER_SEED_OR_MPK = _("Please enter a seed phrase or a master key (xpub or xprv):")
@@ -102,7 +103,7 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
     def __init__(self, config, app, plugins, storage):
         BaseWizard.__init__(self, config, storage)
         QDialog.__init__(self, None)
-        self.setWindowTitle('Electron Cash  -  ' + _('Install Wizard'))
+        self.setWindowTitle(f'{PROJECT_NAME}  -  ' + _('Install Wizard'))
         self.app = app
         self.config = config
         # Set for base base class
@@ -175,7 +176,7 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
         hbox2.addWidget(self.pw_e)
         hbox2.addStretch()
         vbox.addLayout(hbox2)
-        self.set_layout(vbox, title=_('Electron Cash wallet'))
+        self.set_layout(vbox, title=_(f'{PROJECT_NAME} wallet'))
 
         wallet_folder = os.path.dirname(self.storage.path)
 
@@ -257,7 +258,9 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
 
         if self.storage.requires_upgrade():
             self.hide()
-            msg = _("The format of your wallet '%s' must be upgraded for Electron Cash. This change will not be backward compatible"%path)
+            msg = _(f"The format of your wallet {path} must be upgraded for "
+                    f"{PROJECT_NAME}. This change will not be backward "
+                    f"compatible")
             if not self.question(msg):
                 return
             self.storage.upgrade()
@@ -510,12 +513,13 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
         return None
 
     def init_network(self, network):
-        message = _("Electron Cash communicates with remote servers to get "
-                  "information about your transactions and addresses. The "
-                  "servers all fulfil the same purpose only differing in "
-                  "hardware. In most cases you simply want to let Electron Cash "
-                  "pick one at random.  However if you prefer feel free to "
-                  "select a server manually.")
+        message = _(
+            f"{PROJECT_NAME} communicates with remote servers to get "
+            "information about your transactions and addresses. The "
+            "servers all fulfil the same purpose only differing in "
+            f"hardware. In most cases you simply want to let {PROJECT_NAME} "
+            "pick one at random.  However if you prefer feel free to "
+            "select a server manually.")
         choices = [_("Auto connect"), _("Select server manually")]
         title = _("How do you want to connect to a server? ")
         clayout = ChoicesLayout(message, choices)

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -56,6 +56,7 @@ from electroncash import paymentrequest
 from electroncash.transaction import OPReturn
 from electroncash.wallet import Multisig_Wallet, sweep_preparations
 from electroncash.contacts import Contact
+from electroncash.constants import PROJECT_NAME
 try:
     from electroncash.plot import plot_history
 except:
@@ -506,7 +507,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         if is_old_bad:
             msg = ' '.join([
                 _("This testnet wallet has an invalid master key format."),
-                _("(Old versions of Electron Cash before 3.3.6 produced invalid testnet wallets)."),
+                _(f"(Old versions of {PROJECT_NAME} before 3.3.6 produced invalid testnet wallets)."),
                 '<br><br>',
                 _("In order to use this wallet without errors with this version of EC, please <b>re-generate this wallet from seed</b>."),
                 "<br><br><em><i>~SPV stopped~</i></em>"
@@ -555,7 +556,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
                 self.show_message(_("A copy of your wallet file was created in")+" '%s'" % str(new_path), title=_("Wallet backup created"))
             except (IOError, os.error) as reason:
-                self.show_critical(_("Electron Cash was unable to copy your wallet file to the specified location.") + "\n" + str(reason), title=_("Unable to create backup"))
+                self.show_critical(
+                    _(f"{PROJECT_NAME} was unable to copy your wallet file to"
+                      f" the specified location.") + "\n" + str(reason),
+                    title=_("Unable to create backup"))
 
     def update_recently_visited(self, filename):
         recent = self.config.get('recently_open', [])
@@ -743,14 +747,25 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.show_error(_('No donation address for this server'))
 
     def show_about(self):
-        QMessageBox.about(self, "Electron Cash",
-            "<p><font size=+3><b>Electron Cash</b></font></p><p>" + _("Version") + f" {self.wallet.electrum_version}" + "</p>" +
+        year_start = 2017
+        year_end = 2020
+        QMessageBox.about(
+            self, f"{PROJECT_NAME}",
+            f"<p><font size=+3><b>{PROJECT_NAME}</b></font></p><p>"
+            + _("Version") + f" {self.wallet.electrum_version}" + "</p>" +
             '<span style="font-size:11pt; font-weight:500;"><p>' +
-            _("Copyright © {year_start}-{year_end} Electron Cash LLC and the Electron Cash developers.").format(year_start=2017, year_end=2020) +
+            _(f"Copyright © {year_start}-{year_end} Electron Cash LLC and "
+              f"the Electron Cash developers.") +
             "</p><p>" + _("darkdetect for macOS © 2019 Alberto Sottile") + "</p>"
             "</span>" +
             '<span style="font-weight:200;"><p>' +
-            _("Electron Cash's focus is speed, with low resource usage and simplifying Bitcoin Cash. You do not need to perform regular backups, because your wallet can be recovered from a secret phrase that you can memorize or write on paper. Startup times are instant because it operates in conjunction with high-performance servers that handle the most complicated parts of the Bitcoin Cash system.") +
+            _(f"{PROJECT_NAME}'s focus is speed, with low resource usage and"
+              f" simplifying Bitcoin Cash. You do not need to perform regular "
+              f"backups, because your wallet can be recovered from a secret "
+              f"phrase that you can memorize or write on paper. Startup times "
+              f"are instant because it operates in conjunction with "
+              f"high-performance servers that handle the most complicated "
+              f"parts of the Bitcoin Cash system.") +
             "</p></span>"
         )
 
@@ -758,10 +773,14 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         msg = ' '.join([
             _("Please report any bugs as issues on github:<br/>"),
             "<a href=\"https://github.com/Electron-Cash/Electron-Cash/issues\">https://github.com/Electron-Cash/Electron-Cash/issues</a><br/><br/>",
-            _("Before reporting a bug, upgrade to the most recent version of Electron Cash (latest release or git HEAD), and include the version number in your report."),
+            _(f"Before reporting a bug, upgrade to the most recent version of "
+              f"{PROJECT_NAME} (latest release or git HEAD), and include the "
+              f"version number in your report."),
             _("Try to explain not only what the bug is, but how it occurs.")
          ])
-        self.show_message(msg, title="Electron Cash - " + _("Reporting Bugs"), rich_text = True)
+        self.show_message(msg,
+                          title=f"{PROJECT_NAME} - " + _("Reporting Bugs"),
+                          rich_text = True)
 
     def notify(self, message):
         self.gui_object.notify(message)
@@ -1189,9 +1208,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.expires_combo.setFixedWidth(self.receive_amount_e.width())
         msg = ' '.join([
             _('Expiration date of your request.'),
-            _('This information is seen by the recipient if you send them a signed payment request.'),
-            _('Expired requests have to be deleted manually from your list, in order to free the corresponding Bitcoin Cash addresses.'),
-            _('The Bitcoin Cash address never expires and will always be part of this Electron Cash wallet.'),
+            _('This information is seen by the recipient if you send them'
+              ' a signed payment request.'),
+            _('Expired requests have to be deleted manually from your list,'
+              ' in order to free the corresponding Bitcoin Cash addresses.'),
+            _(f'The Bitcoin Cash address never expires and will always be '
+              f'part of this {PROJECT_NAME} wallet.'),
         ])
         label = HelpLabel(_('Request &expires'), msg)
         label.setBuddy(self.expires_combo)
@@ -2802,7 +2824,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         sb.addPermanentWidget(self.search_box, 1)
 
         self.update_available_button = StatusBarButton(QIcon(":icons/electron-cash-update.svg"), _("Update available, click for details"), lambda: self.gui_object.show_update_checker(self, skip_check=True))
-        self.update_available_button.setStatusTip(_("An Electron Cash update is available"))
+        self.update_available_button.setStatusTip(
+            _(f"An {PROJECT_NAME} update is available"))
         sb.addPermanentWidget(self.update_available_button)
         self.update_available_button.setVisible(bool(self.gui_object.new_version_available))  # if hidden now gets unhidden by on_update_available when a new version comes in
 
@@ -3118,7 +3141,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                            "private key, and verifying with the corresponding public key. The "
                            "address you have entered does not have a unique public key, so these "
                            "operations cannot be performed.") + '\n\n' +
-                         _('The operation is undefined. Not just in Electron Cash, but in general.') )
+                         _(f'The operation is undefined. Not just in '
+                           f'{PROJECT_NAME}, but in general.') )
             self.show_message(_('Cannot sign messages with this type of address.') + '\n\n' + msg_sign)
             return
         if self.wallet.is_watching_only():
@@ -3277,7 +3301,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         except:
             if util.is_verbose:
                 traceback.print_exc(file=sys.stderr)
-            self.show_critical(_("Electron Cash was unable to parse your transaction"))
+            self.show_critical(_(f"{PROJECT_NAME} was unable to parse your transaction"))
             return
 
     # Due to the asynchronous nature of the qr reader we need to keep the
@@ -3344,7 +3368,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             file_content = file_content.strip()
             tx_file_dict = json.loads(str(file_content))
         except (ValueError, IOError, OSError, json.decoder.JSONDecodeError) as reason:
-            self.show_critical(_("Electron Cash was unable to open your transaction file") + "\n" + str(reason), title=_("Unable to read file or no transaction found"))
+            self.show_critical(
+                _(f"{PROJECT_NAME} was unable to open your transaction file")
+                + "\n" + str(reason),
+                title=_("Unable to read file or no transaction found"))
             return
         tx = self.tx_from_text(file_content)
         return tx
@@ -3359,7 +3386,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             if tx:
                 self.show_transaction(tx)
         except SerializationError as e:
-            self.show_critical(_("Electron Cash was unable to deserialize the transaction:") + "\n" + str(e))
+            self.show_critical(
+                _(f"{PROJECT_NAME} was unable to deserialize the "
+                  f"transaction:") +
+                "\n" + str(e))
 
     def do_process_from_file(self, *, fileName = None):
         from electroncash.transaction import SerializationError
@@ -3368,7 +3398,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             if tx:
                 self.show_transaction(tx)
         except SerializationError as e:
-            self.show_critical(_("Electron Cash was unable to deserialize the transaction:") + "\n" + str(e))
+            self.show_critical(
+                _(f"{PROJECT_NAME} was unable to deserialize the"
+                  f" transaction:") +
+                "\n" + str(e))
 
     def do_process_from_txid(self, *, txid=None, parent=None, tx_desc=None):
         parent = parent or self
@@ -3406,7 +3439,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         if bip38:
             if not bitcoin.Bip38Key.canEncrypt() or not bitcoin.Bip38Key.isFast():
-                self.show_error(_("BIP38 Encryption is not available. Please install 'pycryptodomex' and restart Electron Cash to enable BIP38."))
+                self.show_error(
+                    _("BIP38 Encryption is not available. Please install "
+                      f"'pycryptodomex' and restart {PROJECT_NAME} to enable"
+                      f"BIP38."))
                 return
             passphrase = self.get_passphrase_dialog(
                 msg = (
@@ -3559,7 +3595,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.do_export_privkeys(filename, private_keys, csv_button.isChecked())
         except (IOError, os.error) as reason:
             txt = "\n".join([
-                _("Electron Cash was unable to produce a private key-export."),
+                _(f"{PROJECT_NAME} was unable to produce a private"
+                  f"key-export."),
                 str(reason)
             ])
             self.show_critical(txt, title=_("Unable to create csv"))
@@ -3594,7 +3631,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 self.wallet.set_label(key, value)
             self.show_message(_("Your labels were imported from") + " '%s'" % str(labelsFile))
         except (IOError, OSError, json.decoder.JSONDecodeError) as reason:
-            self.show_critical(_("Electron Cash was unable to import your labels.") + "\n" + str(reason))
+            self.show_critical(
+                _(f"{PROJECT_NAME} was unable to import your labels.") +
+                "\n" + str(reason))
         self.address_list.update()
         self.history_list.update()
         self.utxo_list.update()
@@ -3609,7 +3648,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                     json.dump(labels, f, indent=4, sort_keys=True)
                 self.show_message(_("Your labels were exported to") + " '%s'" % str(fileName))
         except (IOError, os.error) as reason:
-            self.show_critical(_("Electron Cash was unable to export your labels.") + "\n" + str(reason))
+            self.show_critical(
+                _(f"{PROJECT_NAME} was unable to export your labels.")
+                + "\n" + str(reason))
 
     def export_history_dialog(self):
         d = WindowModalDialog(self.top_level_window(), _('Export History'))
@@ -3664,7 +3705,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                                              timeout=timeout,
                                              include_addresses=include_addresses_chk.isChecked())
         except Exception as reason:
-            export_error_label = _("Electron Cash was unable to produce a transaction export.")
+            export_error_label = _(
+                f"{PROJECT_NAME} was unable to produce a transaction export.")
             self.show_critical(export_error_label + "\n" + str(reason), title=_("Unable to export history"))
         else:
             if success:
@@ -4112,11 +4154,15 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         cr_chk = QCheckBox()
         cr_chk.setChecked(ew.is_enabled(self.config))
         cr_chk.clicked.connect(lambda b: ew.set_enabled(self.config, b))
-        cr_help = HelpLabel(_("Crash reporter enabled"),
-                            _("The crash reporter is the error window which pops-up when Electron Cash encounters an internal error.\n\n"
-                              "It is recommended that you leave this option enabled, so that developers can be notified of any internal bugs. "
-                              "When a crash is encountered you are asked if you would like to send a report.\n\n"
-                              "Private information is never revealed in crash reports to developers."))
+        cr_help = HelpLabel(
+            _("Crash reporter enabled"),
+            _("The crash reporter is the error window which pops-up when "
+              f"{PROJECT_NAME} encounters an internal error.\n\n"
+              "It is recommended that you leave this option enabled, so that "
+              "developers can be notified of any internal bugs. "
+              "When a crash is encountered you are asked if you would like "
+              "to send a report.\n\nPrivate information is never revealed "
+              "in crash reports to developers."))
         # The below dance ensures the checkbox is horizontally centered in the widget
         cr_grid.addWidget(QWidget(), 0, 0, 1, 1)  # dummy spacer
         cr_grid.addWidget(cr_chk, 0, 1, 1, 1, Qt.AlignRight)
@@ -4320,7 +4366,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         gui_widgets.append((None, None)) # spacer
         updatecheck_cb = QCheckBox(_("Automatically check for updates"))
         updatecheck_cb.setChecked(self.gui_object.has_auto_update_check())
-        updatecheck_cb.setToolTip(_("Enable this option if you wish to be notified as soon as a new version of Electron Cash becomes available"))
+        updatecheck_cb.setToolTip(
+            _("Enable this option if you wish to be notified as soon as a "
+              f"new version of {PROJECT_NAME} becomes available"))
         def on_set_updatecheck(v):
             self.gui_object.set_auto_update_check(v == Qt.Checked)
         updatecheck_cb.stateChanged.connect(on_set_updatecheck)
@@ -4587,7 +4635,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         run_hook('close_settings_dialog')
         if self.need_restart:
-            self.show_message(_('Please restart Electron Cash to activate the new GUI settings'), title=_('Success'))
+            self.show_message(
+                _(f'Please restart {PROJECT_NAME} to activate the new GUI'
+                  f' settings'),
+                title=_('Success'))
 
     def closeEvent(self, event):
         # It seems in some rare cases this closeEvent() is called twice.
@@ -5003,7 +5054,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             help_msg = '<span style="font-weight:400;">' + \
                        _('<p>How it works: <b>Cash Accounts</b> registrations work by issuing an <b>OP_RETURN</b> transaction to yourself, costing fractions of a penny.</p>'
                          '<p>The registrations are permanently written to the blockchain and associate a human-friendly name with your address.</p>'
-                         '<p>After the registration transaction receives <i>1 confirmation</i>, you can use your new <b>Cash Account name</b> as if it were an address and give it out to other people (Electron Cash or another Cash Account enabled wallet is required).</p>'
+                         '<p>After the registration transaction receives <i>1 confirmation</i>, you can use your new <b>Cash Account name</b> as if it were an address and give it out to other people (another Cash Account enabled wallet is required).</p>'
                          '<p><span style="font-weight:100;">You will be offered the opportunity to review the generated transaction before broadcasting it to the blockchain.</span></p>') + \
                        '</span>'
             qmark = ":icons/question-mark-dark.svg" if ColorScheme.dark_scheme else ":icons/question-mark-light.svg"
@@ -5066,7 +5117,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 _("The Send Tab has been filled-in with your <b>Cash Accounts</b> registration data.")
                 + "<br><br>" + _("Please review the transaction, save it, and/or broadcast it at your leisure.")
             )
-            msg2 = ( _("After at least <i>1 confirmation</i>, you will be able to use your new <b>Cash Account</b>, and it will be visible in Electron Cash in the <b>Addresses</b> tab.")
+            msg2 = (
+                _("After at least <i>1 confirmation</i>, you will be able to "
+                  "use your new <b>Cash Account</b>, and it will be visible "
+                  f"in {PROJECT_NAME} in the <b>Addresses</b> tab.")
             )
             msg3 = _("If you wish to control which specific coins are used to "
                      "fund this registration transaction, feel free to use the "

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -459,14 +459,14 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.setGeometry(100, 100, 840, 400)
 
     def watching_only_changed(self):
-        title = '%s %s  -  %s' % (networks.net.TITLE,
+        title = '%s %s  -  %s' % (PROJECT_NAME,
                                   self.wallet.electrum_version,
                                   self.wallet.basename())
         extra = [self.wallet.storage.get('wallet_type', '?')]
         if self.wallet.is_watching_only():
             self.warn_if_watching_only()
             extra.append(_('watching only'))
-        title += '  [%s]'% ', '.join(extra)
+        title += '  [%s]' % ', '.join(extra)
         self.setWindowTitle(title)
         self.password_menu.setEnabled(self.wallet.can_change_password())
         self.import_privkey_menu.setVisible(self.wallet.can_import_privkey())

--- a/electroncash_gui/qt/network_dialog.py
+++ b/electroncash_gui/qt/network_dialog.py
@@ -38,6 +38,7 @@ from electroncash.util import print_error, Weak, PrintError, in_main_thread
 from electroncash.network import serialize_server, deserialize_server, get_eligible_servers
 from electroncash.plugins import run_hook
 from electroncash.tor import TorController
+from electroncash.constants import PROJECT_NAME
 
 from .util import *
 from .utils import UserPortValidator
@@ -410,22 +411,33 @@ class NetworkChoiceLayout(QObject, PrintError):
         self.autoconnect_cb.clicked.connect(self.update)
 
         msg = ' '.join([
-            _("If auto-connect is enabled, Electron Cash will always use a server that is on the longest blockchain."),
-            _("If it is disabled, you have to choose a server you want to use. Electron Cash will warn you if your server is lagging.")
+            _(f"If auto-connect is enabled, {PROJECT_NAME} will always use a "
+              f"server that is on the longest blockchain."),
+            _("If it is disabled, you have to choose a server you want to use."
+              f" {PROJECT_NAME} will warn you if your server is lagging.")
         ])
         grid.addWidget(self.autoconnect_cb, 0, 0, 1, 3)
         grid.addWidget(HelpButton(msg), 0, 4)
 
         self.preferred_only_cb = QCheckBox(_("Connect only to preferred servers"))
         self.preferred_only_cb.setEnabled(self.config.is_modifiable('whitelist_servers_only'))
-        self.preferred_only_cb.setToolTip(_("If enabled, restricts Electron Cash to connecting to servers only marked as 'preferred'."))
+        self.preferred_only_cb.setToolTip(
+            _(f"If enabled, restricts {PROJECT_NAME} to connecting to "
+              f"servers only marked as 'preferred'."))
 
         self.preferred_only_cb.clicked.connect(self.set_whitelisted_only) # re-set the config key and notify network.py
 
         msg = '\n\n'.join([
-            _("If 'Connect only to preferred servers' is enabled, Electron Cash will only connect to servers marked as 'preferred' servers ({}).").format(ServerFlag.Symbol[ServerFlag.Preferred]),
-            _("This feature was added in response to the potential for a malicious actor to deny service via launching many servers (aka a sybil attack)."),
-            _("If unsure, most of the time it's safe to leave this option disabled. However leaving it enabled is safer (if a little bit discouraging to new server operators wanting to populate their servers).")
+            _(f"If 'Connect only to preferred servers' is enabled, "
+              f"{PROJECT_NAME} will only connect to servers marked as "
+              f"'preferred' servers ({ServerFlag.Symbol[ServerFlag.Preferred]})."),
+            _("This feature was added in response to the potential for a "
+              "malicious actor to deny service via launching many servers "
+              "(aka a sybil attack)."),
+            _("If unsure, most of the time it's safe to leave this option "
+              "disabled. However leaving it enabled is safer (if a little "
+              "bit discouraging to new server operators wanting to populate "
+              "their servers).")
         ])
         grid.addWidget(self.preferred_only_cb, 1, 0, 1, 3)
         grid.addWidget(HelpButton(msg), 1, 4)
@@ -450,9 +462,14 @@ class NetworkChoiceLayout(QObject, PrintError):
         grid.addWidget(label, 6, 0, 1, 4)
         msg = ' '.join([
             _("Preferred servers ({}) are servers you have designated as reliable and/or trustworthy.").format(ServerFlag.Symbol[ServerFlag.Preferred]),
-            _("Initially, the preferred list is the hard-coded list of known-good servers vetted by the Electron Cash developers."),
-            _("You can add or remove any server from this list and optionally elect to only connect to preferred servers."),
-            "\n\n"+_("Banned servers ({}) are servers deemed unreliable and/or untrustworthy, and so they will never be connected-to by Electron Cash.").format(ServerFlag.Symbol[ServerFlag.Banned])
+            _("Initially, the preferred list is the hard-coded list of "
+              f"known-good servers vetted by the {PROJECT_NAME} developers."),
+            _("You can add or remove any server from this list and"
+              " optionally elect to only connect to preferred servers."),
+            "\n\n" +
+            _(f"Banned servers ({ServerFlag.Symbol[ServerFlag.Banned]}) "
+              "are servers deemed unreliable and/or untrustworthy, and "
+              f"so they will never be connected-to by {PROJECT_NAME}")
         ])
         grid.addWidget(HelpButton(msg), 6, 4)
 
@@ -539,7 +556,10 @@ class NetworkChoiceLayout(QObject, PrintError):
         grid.addWidget(HelpButton(tor_proxy_help), 3, 4)
         # Proxy settings
         grid.addWidget(self.proxy_cb, 4, 0, 1, 3)
-        grid.addWidget(HelpButton(_('Proxy settings apply to all connections: with Electron Cash servers, but also with third-party services.')), 4, 4)
+        grid.addWidget(HelpButton(
+            _(f'Proxy settings apply to all connections: with {PROJECT_NAME}'
+              f' servers, but also with third-party services.')),
+            4, 4)
         grid.addWidget(self.proxy_mode, 6, 1)
         grid.addWidget(self.proxy_host, 6, 2)
         grid.addWidget(self.proxy_port, 6, 3)
@@ -550,8 +570,10 @@ class NetworkChoiceLayout(QObject, PrintError):
         # Blockchain Tab
         grid = QGridLayout(blockchain_tab)
         msg =  ' '.join([
-            _("Electron Cash connects to several nodes in order to download block headers and find out the longest blockchain."),
-            _("This blockchain is used to verify the transactions sent by your transaction server.")
+            _(f"{PROJECT_NAME} connects to several nodes in order to "
+              f"download block headers and find out the longest blockchain."),
+            _("This blockchain is used to verify the transactions sent by "
+              "your transaction server.")
         ])
         self.status_label = QLabel('')
         self.status_label.setTextInteractionFlags(self.status_label.textInteractionFlags() | Qt.TextSelectableByMouse)
@@ -561,7 +583,8 @@ class NetworkChoiceLayout(QObject, PrintError):
 
         self.server_label = QLabel('')
         self.server_label.setTextInteractionFlags(self.server_label.textInteractionFlags() | Qt.TextSelectableByMouse)
-        msg = _("Electron Cash sends your wallet addresses to a single server, in order to receive your transaction history.")
+        msg = _(f"{PROJECT_NAME} sends your wallet addresses to a single "
+                f"server, in order to receive your transaction history.")
         grid.addWidget(QLabel(_('Server') + ':'), 1, 0)
         grid.addWidget(self.server_label, 1, 1, 1, 3)
         grid.addWidget(HelpButton(msg), 1, 4)
@@ -610,7 +633,9 @@ class NetworkChoiceLayout(QObject, PrintError):
         self.tor_custom_port_cb.setEnabled(avalable and self.tor_enabled.isChecked())
         self.tor_socks_port.setEnabled(avalable and self.tor_custom_port_cb.isChecked())
 
-        tor_enabled_tooltip = [_("This will start a private instance of the Tor proxy controlled by Electron Cash.")]
+        tor_enabled_tooltip = [
+            _(f"This will start a private instance of the Tor proxy "
+              f"controlled by {PROJECT_NAME}.")]
         if not avalable:
             tor_enabled_tooltip.insert(0, _("This feature is unavailable because no Tor binary was found."))
         tor_enabled_tooltip_text = ' '.join(tor_enabled_tooltip)

--- a/electroncash_gui/qt/qrwindow.py
+++ b/electroncash_gui/qt/qrwindow.py
@@ -31,12 +31,13 @@ from electroncash_gui.qt.qrcodewidget import QRCodeWidget, save_to_file, copy_to
 from .util import WWLabel, Buttons, MessageBoxMixin
 from electroncash.i18n import _
 from electroncash.util import Weak
+from electroncash.constants import PROJECT_NAME
 
 class QR_Window(QWidget, MessageBoxMixin):
 
     def __init__(self):
         super().__init__() # Top-level window. Parent needs to hold a reference to us and clean us up appropriately.
-        self.setWindowTitle('Electron Cash - ' + _('Payment Request'))
+        self.setWindowTitle(f'{PROJECT_NAME} - ' + _('Payment Request'))
         self.label = ''
         self.amount = 0
         self.setFocusPolicy(Qt.NoFocus)

--- a/electroncash_gui/qt/seed_dialog.py
+++ b/electroncash_gui/qt/seed_dialog.py
@@ -28,6 +28,7 @@ from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
 from electroncash.i18n import _
 from electroncash import mnemonic
+from electroncash.constants import PROJECT_NAME
 
 from .util import *
 from .qrtextedit import ShowQRTextEdit, ScanQRTextEdit
@@ -207,7 +208,8 @@ class KeysLayout(QVBoxLayout):
 class SeedDialog(WindowModalDialog):
 
     def __init__(self, parent, seed, passphrase, derivation=None, seed_type=None):
-        WindowModalDialog.__init__(self, parent, ('Electron Cash - ' + _('Seed')))
+        WindowModalDialog.__init__(self, parent,
+                                   (f'{PROJECT_NAME} - ' + _('Seed')))
         self.setMinimumWidth(400)
         vbox = QVBoxLayout(self)
         title =  _("Your wallet generation seed is:")

--- a/electroncash_gui/qt/udev_installer.py
+++ b/electroncash_gui/qt/udev_installer.py
@@ -36,6 +36,8 @@ from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QHBoxLayout, QPushButt
 from electroncash.util import _, PrintError
 from electroncash.plugins import Plugins
 from electroncash_gui.qt import WindowModalDialog
+from electroncash.constants import PROJECT_NAME
+
 
 class InstallHardwareWalletSupportDialog(PrintError, WindowModalDialog):
     UDEV_RULES_FILE='/etc/udev/rules.d/20-electron-cash-hw-wallets.rules'
@@ -63,9 +65,15 @@ class InstallHardwareWalletSupportDialog(PrintError, WindowModalDialog):
 
         info_label = QLabel()
         info_label.setText(
-            _('This tool installs hardware wallet "udev rules" on your system.') + ' ' +
-            _('Correct udev rules are required in order for a hardware wallet to be accessed by Electron Cash.') + '\n\n' +
-            _('Note: Installing udev rules requires root access via "sudo", so make sure you are in the sudoers file and/or have Administrator rights on this system!')
+            _('This tool installs hardware wallet "udev rules" on your '
+              'system.') +
+            ' ' +
+            _(f'Correct udev rules are required in order for a hardware wallet'
+              f' to be accessed by {PROJECT_NAME}.') +
+            '\n\n' +
+            _('Note: Installing udev rules requires root access via "sudo", '
+              'so make sure you are in the sudoers file and/or have '
+              'Administrator rights on this system!')
             )
         info_label.setWordWrap(True)
 
@@ -153,7 +161,7 @@ class InstallHardwareWalletSupportDialog(PrintError, WindowModalDialog):
 
         ids_set = self.device_manager.recognised_hardware.union(self.ADDITIONAL_HARDWARE_IDS)
         lines = [line_format.format(ids[0], ids[1]) for ids in ids_set]
-        return '# Electron Cash hardware wallet rules file\n' + '\n'.join(lines) + '\n'
+        return f'# {PROJECT_NAME} hardware wallet rules file\n' + '\n'.join(lines) + '\n'
 
     def _runScriptAsRoot(self, script: str) -> bool:
         assert script

--- a/electroncash_gui/qt/update_checker.py
+++ b/electroncash_gui/qt/update_checker.py
@@ -33,8 +33,10 @@ from electroncash.util import PrintError, print_error
 from electroncash.i18n import _
 from electroncash import version, bitcoin, address
 from electroncash.networks import MainNet
+from electroncash.constants import PROJECT_NAME
 from .util import *
 import base64, sys, requests, threading, time
+
 
 class UpdateChecker(QWidget, PrintError):
     ''' A window that checks for updates.
@@ -74,7 +76,7 @@ class UpdateChecker(QWidget, PrintError):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.setWindowTitle('Electron Cash - ' + _('Update Checker'))
+        self.setWindowTitle(f'{PROJECT_NAME} - ' + _('Update Checker'))
         self.content = QVBoxLayout()
         self.content.setContentsMargins(*([10]*4))
 
@@ -224,7 +226,9 @@ class UpdateChecker(QWidget, PrintError):
                 self.cancel_or_check_button.setEnabled(False)
             else:
                 self.heading_label.setText('<h2>' + _("Already up to date") + '</h2>')
-                self.detail_label.setText(_("You are already on the latest version of Electron Cash."))
+                self.detail_label.setText(
+                    _(f"You are already on the latest version of "
+                      f"{PROJECT_NAME}."))
                 self.cancel_or_check_button.setEnabled(True)
         else:
             self.pb.show()
@@ -233,7 +237,9 @@ class UpdateChecker(QWidget, PrintError):
             self.cancel_or_check_button.setEnabled(True)
             self.latest_version_label.setText("")
             self.heading_label.setText('<h2>' + _("Checking for updates...") + '</h2>')
-            self.detail_label.setText(_("Please wait while Electron Cash checks for available updates."))
+            self.detail_label.setText(
+                _(f"Please wait while {PROJECT_NAME} checks for "
+                  f"available updates."))
 
     def cancel_active(self):
         if self.active_req:

--- a/electrum-bcha
+++ b/electrum-bcha
@@ -40,8 +40,8 @@ if sys.platform == "win32" and hasattr(sys, 'frozen') and hasattr(sys, '_MEIPASS
 os.environ['PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION'] = 'python'
 
 if sys.version_info < (3, 6):
-    sys.exit("*** Electron Cash support for Python 3.5 has been discontinued.\n"
-             "*** Please run Electron Cash with Python 3.6 or above.")
+    sys.exit(f"*** {PROJECT_NAME} support for Python 3.5 has been discontinued.\n"
+             f"*** Please run {PROJECT_NAME} with Python 3.6 or above.")
 
 # from https://gist.github.com/tito/09c42fb4767721dc323d
 import threading
@@ -108,6 +108,8 @@ from electroncash.mnemonic import Mnemonic, Mnemonic_Electrum
 from electroncash.winconsole import create_or_attach_console  # Import ok on other platforms, won't be called.
 import electroncash_plugins
 import electroncash.web as web
+from electroncash.constants import SCRIPT_NAME, PROJECT_NAME
+
 
 # get password routine
 def prompt_password(prompt, confirm=True):
@@ -204,7 +206,7 @@ def init_daemon(config_options):
     storage = WalletStorage(config.get_wallet_path())
     if not storage.file_exists():
         print_msg("Error: Wallet file not found.")
-        print_msg("Type 'electron-cash create' to create a new wallet, or provide a path to a wallet with the -w option")
+        print_msg(f"Type '{SCRIPT_NAME} create' to create a new wallet, or provide a path to a wallet with the -w option")
         sys.exit(0)
     if storage.is_encrypted():
         if 'wallet_password' in config_options:
@@ -242,7 +244,7 @@ def init_cmdline(config_options, server):
 
     if cmd.requires_wallet and not storage.file_exists():
         print_msg("Error: Wallet file not found.")
-        print_msg("Type 'electron-cash create' to create a new wallet, or provide a path to a wallet with the -w option")
+        print_msg(f"Type '{SCRIPT_NAME} create' to create a new wallet, or provide a path to a wallet with the -w option")
         sys.exit(0)
 
     # important warning
@@ -322,7 +324,7 @@ if __name__ == '__main__':
     # On windows, allocate a console if needed
     if sys.platform.startswith('win'):
         require_console = '-v' in sys.argv or '--verbose' in sys.argv
-        console_title = _("Electron Cash - Verbose Output") if require_console else None
+        console_title = _(f"{PROJECT_NAME} - Verbose Output") if require_console else None
         # Attempt to attach to ancestor process console. If create=True we will
         # create a new conole window if no ancestor process console exists.
         # (Presumably if user ran with -v, they expect console output).
@@ -375,7 +377,7 @@ if __name__ == '__main__':
         config_options['portable'] = False
 
     if config_options.get('portable'):
-        config_options['electron_cash_path'] = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'electron_cash_data')
+        config_options['electrum_bcha_path'] = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'electrum_bcha_data')
 
     set_verbosity(config_options.get('verbose'))
 
@@ -472,7 +474,7 @@ if __name__ == '__main__':
         else:
             cmd = known_commands[cmdname]
             if cmd.requires_network:
-                print_msg("Daemon not running; try 'electron-cash daemon start'")
+                print_msg(f"Daemon not running; try '{SCRIPT_NAME} daemon start'")
                 sys.exit(1)
             else:
                 init_plugins(config, 'cmdline')


### PR DESCRIPTION
The name "Electron Cash" was duplicated in a gazillion places. This PR refactors all user-facing strings to use a constant that is defined in a single place.
Also update in a similar way all occurences of the script name "electron-cash".
For now we use "Electrum BCHA" and "electrum-bcha".

This change will break all the translations strings that use the words "Electron Cash", and the corresponding .po files will have to be updated accordingly. This is not a priority, and we can wait until we are sure of the final name for the project before we do this.
