### PR TITLE
Update make_osx to use a secure timestamp when signing

### DIFF
--- a/contrib/osx/make_osx
+++ b/contrib/osx/make_osx
@@ -42,7 +42,7 @@ function DoCodeSignMaybe { # ARGS: infoName fileOrDirName codesignIdentity
       # is required for notarization.
       # See: https://github.com/pyinstaller/pyinstaller/issues/4629
       preserve_arg=""
-      hardened_arg="--entitlements=${build_dir}/entitlements.plist -o runtime"
+      hardened_arg="--entitlements=${build_dir}/entitlements.plist -o runtime --timestamp"
       hardened_info=" (Hardened Runtime)"
     fi
     info "Code signing ${infoName}${hardened_info}..."


### PR DESCRIPTION
When attempting to notorize this application, one of the errors reported
was that the signature does not include a secure timestamp. In order to
fix this, the `--timestamp` command must be passed to the codesign
command. Thus, add it in there.

See:
https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution/resolving_common_notarization_issues