### PR TITLE
Update exchange APIs

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile_ub1804
+++ b/contrib/build-linux/appimage/Dockerfile_ub1804
@@ -10,7 +10,7 @@ RUN echo deb ${UBUNTU_MIRROR} bionic main restricted universe multiverse > /etc/
     echo deb ${UBUNTU_MIRROR} bionic-security main restricted universe multiverse >> /etc/apt/sources.list && \
     apt-get update -q && \
     apt-get install -qy \
-        git=1:2.17.1-1ubuntu0.15 \
+        git=1:2.17.1-1ubuntu0.16 \
         wget=1.19.4-1ubuntu2.2 \
         make=4.1-9.1ubuntu1 \
         autotools-dev=20180224.1 \
@@ -47,7 +47,7 @@ RUN echo deb ${UBUNTU_MIRROR} bionic main restricted universe multiverse > /etc/
         zlib1g-dev=1:1.2.11.dfsg-0ubuntu2 \
         libfreetype6=2.8.1-2ubuntu2.2 \
         libfontconfig1=2.12.6-0ubuntu2 \
-        libssl-dev=1.1.1-1ubuntu2.1~18.04.20 \
+        libssl-dev=1.1.1-1ubuntu2.1~18.04.21 \
         rustc=1.61.0+dfsg1~llvm-1~exp1ubuntu0.18.04.1 \
         cargo=0.62.0ubuntu0libgit2-0ubuntu0.18.04.1 \
         && \

--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -40,7 +40,7 @@ verify_hash "$CACHEDIR/Python-$PYTHON_VERSION.tar.xz" $PYTHON_SRC_TARBALL_HASH
 
 (
     cd "$PROJECT_ROOT"
-    for pkg in secp zbar openssl libevent zlib tor ; do
+    for pkg in secp zbar ; do
         "$CONTRIB"/make_$pkg || fail "Could not build $pkg"
     done
 )

--- a/contrib/build-wine/_build.sh
+++ b/contrib/build-wine/_build.sh
@@ -45,7 +45,7 @@ mkdir -p /tmp/electrum-build
 
 (
     cd "$PROJECT_ROOT"
-    for pkg in secp zbar openssl libevent zlib tor ; do
+    for pkg in secp zbar ; do
         "$here"/../make_$pkg || fail "Could not build $pkg"
     done
 )
@@ -184,7 +184,6 @@ prepare_wine() {
         mkdir -p "$WINEPREFIX"/drive_c/tmp
         cp "$here"/../../electrumabc/*.dll "$WINEPREFIX"/drive_c/tmp/ || fail "Could not copy libraries to their destination"
         cp libusb/libusb/.libs/libusb-1.0.dll "$WINEPREFIX"/drive_c/tmp/ || fail "Could not copy libusb to its destination"
-        cp "$here"/../../electrumabc/tor/bin/tor.exe "$WINEPREFIX"/drive_c/tmp/ || fail "Could not copy tor.exe to its destination"
 
         popd  # out of homedir/tmp
         popd  # out of $here

--- a/contrib/build-wine/deterministic.spec
+++ b/contrib/build-wine/deterministic.spec
@@ -28,9 +28,6 @@ binaries += [('C:/tmp/libsecp256k1-0.dll', '.')]
 # Add zbar libraries
 binaries += [('C:/tmp/libzbar-0.dll', '.')]
 
-# Add tor binary
-binaries += [('C:/tmp/tor.exe', '.')]
-
 # The below is no longer necessary. PyInstaller 3.4+ picks these up properly
 # now and puts them in the Qt dirs.
 # Add Windows OpenGL and D3D implementation DLLs (see #1255 and #1253)

--- a/contrib/build-wine/docker/Dockerfile
+++ b/contrib/build-wine/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN echo deb ${UBUNTU_MIRROR} ${UBUNTUDIST} main restricted universe multiverse 
         gnupg2=2.2.27-3ubuntu2.1 \
         ca-certificates=20211016 \
         wget=1.21.2-2ubuntu1 \
-        git=1:2.34.1-1ubuntu1.6 \
+        git=1:2.34.1-1ubuntu1.8 \
         p7zip-full=16.02+dfsg-8 \
         make=4.3-4.1build1 \
         autotools-dev=20220109.1 \
@@ -51,7 +51,7 @@ RUN echo "78b185fabdb323971d13bd329fefc8038e08559aa51c4996de18db0639a51df6 /tmp/
         # cabextract is needed for winetricks to install the .NET framework
         cabextract=1.9-3 \
         # xvfb is needed to launch the Visual Studio installer
-        xvfb=2:21.1.3-2ubuntu2.5 \
+        xvfb=2:21.1.3-2ubuntu2.7 \
         # winbind is needed for the Visual Studio installer and cl.exe PDB generation
         winbind=2:4.15.13+dfsg-0ubuntu1
 

--- a/contrib/make_linux_sdist
+++ b/contrib/make_linux_sdist
@@ -23,7 +23,7 @@ info "Making SrcDist for version: ${EC_PACKAGE_NAME}-${TAGGED_VERSION} ..."
 
 "$contrib"/make_locale && \
     "$contrib"/make_packages && \
-    python3 setup.py sdist --enable-secp --enable-zbar --enable-tor --format=zip,gztar || fail "Failed."
+    python3 setup.py sdist --enable-secp --enable-zbar --format=zip,gztar || fail "Failed."
 
 unset EC_PACKAGE_NAME TAGGED_VERSION
 

--- a/contrib/osx/make_osx
+++ b/contrib/osx/make_osx
@@ -223,9 +223,6 @@ make -j4 || fail "Could not build secp256k1"
 popd_pkg
 cp -fp contrib/build/secp256k1/.libs/libsecp256k1.0.dylib contrib/osx || fail "Could not copy secp256k1 binary to its destination"
 
-info "Building integrated Tor"
-contrib/make_zlib && contrib/make_libevent && contrib/make_openssl && contrib/make_tor || fail "Could not build Tor"
-
 info "Installing requirements..."
 python3 -m pip install -r ./contrib/deterministic-build/requirements.txt --user || fail "Could not install requirements"
 python3 -m pip install -r ./contrib/deterministic-build/requirements-binaries.txt --user || fail "Could not install binary requirements"
@@ -247,8 +244,6 @@ TMPPACKAGE="Electrum-ABC"
 ELECTRUM_VERSION=$VERSION pyinstaller --clean --noconfirm --ascii contrib/osx/osx.spec || fail "Could not build binary"
 mv dist/$TMPPACKAGE.app dist/$PACKAGE.app
 
-# Sign the Tor binary separately
-DoCodeSignMaybe "tor binary" "dist/${PACKAGE}.app/Contents/MacOS/electrumabc/tor/bin/tor" "$APP_SIGN"
 # Finally, codesign the whole thing
 DoCodeSignMaybe ".app bundle" "dist/${PACKAGE}.app" "$APP_SIGN"
 

--- a/contrib/osx/osx.spec
+++ b/contrib/osx/osx.spec
@@ -48,8 +48,6 @@ binaries = [(home + "contrib/osx/libusb-1.0.dylib", ".")]
 binaries += [(home + "contrib/osx/libsecp256k1.0.dylib", ".")]
 # LibZBar for QR code scanning
 binaries += [(home + "contrib/osx/libzbar.0.dylib", ".")]
-# Add Tor binary
-binaries += [(home + "electrumabc/tor/bin/tor", "electrumabc/tor/bin")]
 
 # Workaround for "Retro Look":
 binaries += [b for b in collect_dynamic_libs('PyQt5') if 'macstyle' in b[0]]

--- a/electrum-abc
+++ b/electrum-abc
@@ -37,6 +37,7 @@ from __future__ import annotations
 import argparse
 import getpass
 import logging
+import multiprocessing
 import os
 import sys
 import threading
@@ -607,4 +608,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # freeze_support() is needed to use multiprocessing with frozen app on MacOS
+    # and Windows
+    # See https://github.com/pyinstaller/pyinstaller/issues/4865
+    # and https://docs.python.org/3/library/multiprocessing.html#multiprocessing.freeze_support
+    multiprocessing.freeze_support()
     main()

--- a/electrumabc/daemon.py
+++ b/electrumabc/daemon.py
@@ -177,9 +177,8 @@ class Daemon(DaemonThread):
         self.plugins = plugins
         self.config = config
         self.listen_jsonrpc = listen_jsonrpc
-        if config.get("offline"):
-            self.network = None
-        else:
+        self.network: Optional[Network] = None
+        if not config.get("offline"):
             self.network = Network(config)
             self.network.start()
         self.fx = FxThread(config, self.network)

--- a/electrumabc/network.py
+++ b/electrumabc/network.py
@@ -22,6 +22,7 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import annotations
 
 import errno
 import json
@@ -388,7 +389,7 @@ class Network(util.DaemonThread):
             super().__del__()
 
     @staticmethod
-    def get_instance():
+    def get_instance() -> Network:
         """Returns the extant Network singleton, if any, or None if in offline mode"""
         return Network.INSTANCE
 

--- a/electrumabc/tor/controller.py
+++ b/electrumabc/tor/controller.py
@@ -90,8 +90,7 @@ class TorController(PrintError):
     @unique
     class BinaryType(IntEnum):
         MISSING = 0
-        INTEGRATED = 1
-        SYSTEM = 2
+        SYSTEM = 1
 
     _tor_process: Optional[subprocess.Popen] = None
     _tor_read_thread: Optional[threading.Thread] = None
@@ -199,15 +198,7 @@ class TorController(PrintError):
 
     @staticmethod
     def _get_tor_binary() -> Tuple[str, BinaryType]:
-        # Try to locate a bundled tor binary
-        if sys.platform in ("windows", "win32"):
-            res = os.path.join(os.path.dirname(__file__), "..", "..", "tor.exe")
-        else:
-            res = os.path.join(os.path.dirname(__file__), "bin", "tor")
-        if os.path.isfile(res):
-            return res, TorController.BinaryType.INTEGRATED
-
-        # Tor is not packaged / built, try to locate a system tor
+        # Try to locate a system tor
         res = shutil.which("tor")
         if res and os.path.isfile(res):
             return res, TorController.BinaryType.SYSTEM

--- a/electrumabc/tor/controller.py
+++ b/electrumabc/tor/controller.py
@@ -91,6 +91,7 @@ class TorController(PrintError):
     class BinaryType(IntEnum):
         MISSING = 0
         SYSTEM = 1
+        DOWNLOADED = 2
 
     _tor_process: Optional[subprocess.Popen] = None
     _tor_read_thread: Optional[threading.Thread] = None
@@ -196,12 +197,16 @@ class TorController(PrintError):
         kwargs["start_new_session"] = True
         return TorController._orig_subprocess_popen(*args, **kwargs)
 
-    @staticmethod
-    def _get_tor_binary() -> Tuple[str, BinaryType]:
+    def _get_tor_binary(self) -> Tuple[str, BinaryType]:
         # Try to locate a system tor
         res = shutil.which("tor")
         if res and os.path.isfile(res):
             return res, TorController.BinaryType.SYSTEM
+
+        # Use the automatically downloaded tor
+        res = self._config.get("downloaded_tor_path")
+        if res and os.path.isfile(res):
+            return res, TorController.BinaryType.DOWNLOADED
 
         return "", TorController.BinaryType.MISSING
 

--- a/electrumabc/wallet.py
+++ b/electrumabc/wallet.py
@@ -52,6 +52,7 @@ from typing import (
     Union,
     ValuesView,
 )
+from weakref import ref
 
 from . import (
     bitcoin,
@@ -108,6 +109,8 @@ from .verifier import SPV, SPVDelegate
 from .version import PACKAGE_VERSION
 
 if TYPE_CHECKING:
+    from electrumabc_gui.qt import ElectrumWindow
+
     from .simple_config import SimpleConfig
 
 
@@ -235,9 +238,9 @@ class AbstractWallet(PrintError, SPVDelegate):
         # verifier (SPV) and synchronizer are started in start_threads
         self.synchronizer = None
         self.verifier: Optional[SPV] = None
-        self.weak_window: Optional[
-            Synchronizer
-        ] = None  # Some of the GUI classes, such as the Qt ElectrumWindow, use this to refer back to themselves.  This should always be a weakref.ref (Weak.ref), or None
+        # Some of the GUI classes, such as the Qt ElectrumWindow, use this to refer
+        # back to themselves.  This should always be a weakref.ref (Weak.ref), or None
+        self.weak_window: Optional[ref[ElectrumWindow]] = None
         self.slp = slp.WalletData(self)
         finalization_print_error(self.slp)  # debug object lifecycle
 

--- a/electrumabc_gui/qt/network_dialog.py
+++ b/electrumabc_gui/qt/network_dialog.py
@@ -49,6 +49,7 @@ from electrumabc.printerror import PrintError, print_error
 from electrumabc.tor import TorController
 from electrumabc.util import Weak, in_main_thread
 
+from .tor_downloader import DownloadTorDialog
 from .util import (
     Buttons,
     CloseButton,
@@ -1375,7 +1376,8 @@ class NetworkChoiceLayout(QObject, PrintError):
         return False
 
     def _show_download_tor_dialog(self):
-        print("TODO: implement download tor dialog")
+        dialog = DownloadTorDialog(self.config, self.parent())
+        dialog.exec_()
 
 
 class TorDetector(QThread):

--- a/electrumabc_gui/qt/network_dialog.py
+++ b/electrumabc_gui/qt/network_dialog.py
@@ -706,9 +706,25 @@ class NetworkChoiceLayout(QObject, PrintError):
             UserPortValidator(self.tor_socks_port, accept_zero=True)
         )
 
+        self.dl_tor_button = QtWidgets.QPushButton(_("Download Tor"))
+        self.dl_tor_button.clicked.connect(self._show_download_tor_dialog)
+        self.dl_tor_help = HelpButton(
+            _("Download a compiled Tor executable.")
+            + "\n\n"
+            + _(
+                f"A Tor executable is provided by {PROJECT_NAME} for convenience, if "
+                "you don't know how to install Tor on your operating system. Linux "
+                "users are advised to install Tor via their package manager instead."
+            )
+            + "\n\n"
+            + _(f"Restart {PROJECT_NAME} after the download is complete.")
+        )
+
         self.update_tor_enabled()
 
         # Start Tor
+        grid.addWidget(self.dl_tor_button, 0, 1, 1, 2)
+        grid.addWidget(self.dl_tor_help, 0, 4)
         grid.addWidget(self.tor_enabled, 1, 0, 1, 2)
         grid.addWidget(self.tor_enabled_help, 1, 4)
         # Custom Tor port
@@ -880,6 +896,10 @@ class NetworkChoiceLayout(QObject, PrintError):
     def update_tor_enabled(self, *args):
         tbt = self.network.tor_controller.tor_binary_type
         tbname = self._tor_client_names[tbt]
+        available = tbt != TorController.BinaryType.MISSING
+
+        self.dl_tor_button.setVisible(not available)
+        self.dl_tor_help.setVisible(not available)
 
         self.tor_enabled.setText(
             _("Start {tor_binary_name} client").format(
@@ -887,7 +907,6 @@ class NetworkChoiceLayout(QObject, PrintError):
                 tor_binary_name_capitalized=tbname[:1].upper() + tbname[1:],
             )
         )
-        available = tbt != TorController.BinaryType.MISSING
         self.tor_enabled.setEnabled(available)
         self.tor_custom_port_cb.setEnabled(available and self.tor_enabled.isChecked())
         self.tor_socks_port.setEnabled(
@@ -1354,6 +1373,9 @@ class NetworkChoiceLayout(QObject, PrintError):
             self.update()
             return True
         return False
+
+    def _show_download_tor_dialog(self):
+        print("TODO: implement download tor dialog")
 
 
 class TorDetector(QThread):

--- a/electrumabc_gui/qt/network_dialog.py
+++ b/electrumabc_gui/qt/network_dialog.py
@@ -40,6 +40,7 @@ from electrumabc.constants import PROJECT_NAME
 from electrumabc.i18n import _, pgettext
 from electrumabc.interface import Interface
 from electrumabc.network import (
+    Network,
     deserialize_server,
     get_eligible_servers,
     serialize_server,
@@ -70,7 +71,7 @@ protocol_letters = "ts"
 class NetworkDialog(MessageBoxMixin, QtWidgets.QDialog):
     network_updated_signal = pyqtSignal()
 
-    def __init__(self, network, config):
+    def __init__(self, network: Network, config):
         QtWidgets.QDialog.__init__(self)
         self.setWindowTitle(_("Network"))
         self.setMinimumSize(500, 350)
@@ -455,7 +456,7 @@ class ServerListWidget(QtWidgets.QTreeWidget):
 
 
 class NetworkChoiceLayout(QObject, PrintError):
-    def __init__(self, parent, network, config, wizard=False):
+    def __init__(self, parent, network: Network, config, wizard=False):
         super().__init__(parent)
         self.network = network
         self.config = config
@@ -1383,7 +1384,7 @@ class NetworkChoiceLayout(QObject, PrintError):
 class TorDetector(QThread):
     found_proxy = pyqtSignal(object)
 
-    def __init__(self, parent, network):
+    def __init__(self, parent, network: Network):
         super().__init__(parent)
         self.network = network
         self.network.tor_controller.active_port_changed.append_weak(

--- a/electrumabc_gui/qt/network_dialog.py
+++ b/electrumabc_gui/qt/network_dialog.py
@@ -874,6 +874,7 @@ class NetworkChoiceLayout(QObject, PrintError):
     _tor_client_names = {
         TorController.BinaryType.MISSING: _("Tor"),
         TorController.BinaryType.SYSTEM: _("system Tor"),
+        TorController.BinaryType.DOWNLOADED: _("downloaded Tor"),
     }
 
     def update_tor_enabled(self, *args):

--- a/electrumabc_gui/qt/network_dialog.py
+++ b/electrumabc_gui/qt/network_dialog.py
@@ -874,7 +874,6 @@ class NetworkChoiceLayout(QObject, PrintError):
     _tor_client_names = {
         TorController.BinaryType.MISSING: _("Tor"),
         TorController.BinaryType.SYSTEM: _("system Tor"),
-        TorController.BinaryType.INTEGRATED: _("integrated Tor"),
     }
 
     def update_tor_enabled(self, *args):

--- a/electrumabc_gui/qt/network_dialog.py
+++ b/electrumabc_gui/qt/network_dialog.py
@@ -718,8 +718,6 @@ class NetworkChoiceLayout(QObject, PrintError):
                 "you don't know how to install Tor on your operating system. Linux "
                 "users are advised to install Tor via their package manager instead."
             )
-            + "\n\n"
-            + _(f"Restart {PROJECT_NAME} after the download is complete.")
         )
 
         self.update_tor_enabled()
@@ -1379,6 +1377,9 @@ class NetworkChoiceLayout(QObject, PrintError):
     def _show_download_tor_dialog(self):
         dialog = DownloadTorDialog(self.config, self.parent())
         dialog.exec_()
+        # Let TorController know about the new binary
+        if dialog.was_download_successful:
+            self.network.tor_controller.detect_tor()
 
 
 class TorDetector(QThread):

--- a/electrumabc_gui/qt/tor_downloader.py
+++ b/electrumabc_gui/qt/tor_downloader.py
@@ -133,6 +133,7 @@ class Downloader:
 class DownloadTorDialog(QtWidgets.QDialog):
     def __init__(self, config: SimpleConfig, parent=None):
         self.config = config
+        self.was_download_successful = False
 
         super().__init__(parent)
         self.setWindowTitle("Tor downloader")
@@ -205,10 +206,10 @@ class DownloadTorDialog(QtWidgets.QDialog):
         self.label.setText(
             _("Tor was successfully downloaded and saved to")
             + f"\n{TOR_BINARY_PATH}\n\n"
-            + _("You need to restart Electrum ABC to use it.")
         )
         self.cancel_button.setVisible(False)
         self.ok_button.setVisible(True)
+        self.was_download_successful = True
 
     def on_error(self, error: str):
         self.label.setText(error)

--- a/electrumabc_gui/qt/tor_downloader.py
+++ b/electrumabc_gui/qt/tor_downloader.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+#
+# Electrum ABC - lightweight eCash client
+# Copyright (C) 2023 The Electrum ABC developers
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import multiprocessing
+
+import requests
+
+
+class Downloader:
+    """URL downloader designed to be run as a separate process and to communicate
+    with the main process via a Queue.
+
+    multiprocessing is used because of pythons multi-threading limitations, and
+    because an alternative solution based on QNetworkAccessManager would not work
+    for any HTTPS URL (SSL issues).
+
+    The queue can be monitored for the following messages (as str objects):
+
+      - "@started@"
+      - "@HTTP status@ {status code} {reason}"
+        (e.g "@HTTP status@ 200 OK")
+      - "@content size@ {size in bytes}"
+      - "@finished@"
+    """
+
+    def __init__(self, url: str, filename: str):
+        self.url = url
+        self.filename = filename
+
+        self.queue = multiprocessing.Queue()
+
+    def run_download(self):
+        self.queue.put("@started@")
+        r = requests.get(url)
+        self.queue.put(f"@HTTP status@ {r.status_code} {r.reason}")
+        self.queue.put(f"@content size@ {len(r.content)}")
+        with open(self.filename, "wb") as f:
+            f.write(r.content)
+        self.queue.put("@finished@")
+
+
+if __name__ == "__main__":
+    # Code sample to better document the API
+    import os
+    import sys
+    from pathlib import Path
+
+    from PyQt5.QtCore import QTimer
+    from PyQt5.QtWidgets import QApplication
+
+    url = sys.argv[1]
+    fname = sys.argv[2]
+
+    dl_path = os.path.join(str(Path.home()), "test_dl")
+    os.makedirs(dl_path, exist_ok=True)
+    app = QApplication([])
+
+    downloader = Downloader(url, os.path.join(dl_path, fname))
+    process = multiprocessing.Process(target=downloader.run_download)
+
+    timer = QTimer()
+
+    def read_queue():
+        while not downloader.queue.empty():
+            msg = downloader.queue.get()
+            print(msg)
+            if msg == "@finished@":
+                timer.stop()
+
+    timer.timeout.connect(read_queue)
+    timer.timeout.connect(lambda: print("."))
+
+    process.start()
+    # Read the queue every second
+    timer.start(1000)
+
+    app.exec_()

--- a/electrumabc_plugins/fusion/qt.py
+++ b/electrumabc_plugins/fusion/qt.py
@@ -70,6 +70,7 @@ from .util import get_coin_name
 
 if TYPE_CHECKING:
     from electrumabc_gui.qt.address_list import AddressList
+    from electrumabc_gui.qt import ElectrumGui
 
 from pathlib import Path
 
@@ -110,7 +111,7 @@ class Plugin(FusionPlugin, QObject):
 
     fusions_win = None
     weak_settings_tab = None
-    gui = None
+    gui: Optional[ElectrumGui] = None
     initted = False
     last_server_status = (True, ("Ok", ""))
     _hide_history_txs = False
@@ -680,7 +681,9 @@ class Plugin(FusionPlugin, QObject):
 
     _integrated_tor_timer = None
 
-    def _maybe_prompt_user_if_they_want_integrated_tor_if_no_tor_found(self, wallet):
+    def _maybe_prompt_user_if_they_want_integrated_tor_if_no_tor_found(
+        self, wallet: AbstractWallet
+    ):
         if self._integrated_tor_timer:
             # timer already active or already prompted user
             return
@@ -691,7 +694,7 @@ class Plugin(FusionPlugin, QObject):
             return
 
         def chk_tor_ok():
-            self = weak_self()
+            self: Optional[Plugin] = weak_self()
             if not self:
                 return
             self._integrated_tor_timer = None  # kill QTimer reference

--- a/setup.py
+++ b/setup.py
@@ -117,8 +117,6 @@ class MakeAllBeforeSdist(setuptools.command.sdist.sdist):
         ("enable-secp", None, "Enable libsecp256k1 complilation."),
         ("disable-zbar", None, "Disable libzbar complilation (default)."),
         ("enable-zbar", None, "Enable libzbar complilation."),
-        ("disable-tor", None, "Disable tor complilation (default)."),
-        ("enable-tor", None, "Enable tor complilation."),
     ]
 
     def initialize_options(self):
@@ -126,8 +124,6 @@ class MakeAllBeforeSdist(setuptools.command.sdist.sdist):
         self.enable_secp = None
         self.disable_zbar = None
         self.enable_zbar = None
-        self.disable_tor = None
-        self.enable_tor = None
         super().initialize_options()
 
     def finalize_options(self):
@@ -137,9 +133,6 @@ class MakeAllBeforeSdist(setuptools.command.sdist.sdist):
         if self.enable_zbar is None:
             self.enable_zbar = False
         self.enable_zbar = not self.disable_zbar and self.enable_zbar
-        if self.enable_tor is None:
-            self.enable_tor = False
-        self.enable_tor = not self.disable_tor and self.enable_tor
         super().finalize_options()
 
     def run(self):
@@ -156,19 +149,6 @@ class MakeAllBeforeSdist(setuptools.command.sdist.sdist):
         if self.enable_zbar:
             self.announce("Running make_zbar...")
             0 == os.system("contrib/make_zbar") or sys.exit("Could not build libzbar")
-        if self.enable_tor:
-            self.announce("Running make_openssl...")
-            0 == os.system("contrib/make_openssl") or sys.exit(
-                "Could not build openssl"
-            )
-            self.announce("Running make_libevent...")
-            0 == os.system("contrib/make_libevent") or sys.exit(
-                "Could not build libevent"
-            )
-            self.announce("Running make_zlib...")
-            0 == os.system("contrib/make_zlib") or sys.exit("Could not build zlib")
-            self.announce("Running make_tor...")
-            0 == os.system("contrib/make_tor") or sys.exit("Could not build tor")
         super().run()
 
 
@@ -233,7 +213,6 @@ setup(
             "libsecp256k1*",
             "libzbar*",
             "locale/*/LC_MESSAGES/electron-cash.mo",
-            "tor/bin/*",
         ],
         "electrumabc_plugins.fusion": ["*.svg", "*.png"],
         # On Linux and Windows this means adding electrumabc_gui/qt/data/*.ttf


### PR DESCRIPTION
Remove deceased price APIs.

Add another API (cryptocompare.com), as a fallback in case CoinGecko is down.